### PR TITLE
Add inverter mode transition checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 - [Grid-code evidence prompt](concepts/grid-code-evidence-prompt.md)
 - [Storage dispatch basics](concepts/storage-dispatch-basics.md)
 - [Weak-grid storage review checklist](checklists/weak-grid-storage-review-checklist.md)
+- [Inverter mode transition checklist](checklists/inverter-mode-transition-checklist.md)
 - [Storage glossary](glossary/storage-glossary.md)
 - [BESS control flow](diagrams/bess-control-flow.md)
 
@@ -46,3 +47,4 @@ LICENSE
 - Improve weak-grid review prompts with project examples.
 - Add project-specific examples to the grid-code evidence prompt.
 - Improve the BESS control-flow diagram notes.
+- Add project-specific inverter mode transition examples.

--- a/checklists/inverter-mode-transition-checklist.md
+++ b/checklists/inverter-mode-transition-checklist.md
@@ -1,0 +1,19 @@
+# Inverter Mode Transition Checklist
+
+Use this checklist to review transitions between grid-following, grid-forming, standby, and fault states.
+
+| Transition | Command Owner | Trigger | Allowed Transition | Evidence | Status |
+|---|---|---|---|---|---|
+| Standby to grid-following | EMS / operator | Grid available and PCS enabled | Standby -> grid-following | Control narrative, SCADA command record | Not started |
+| Grid-following to grid-forming | EMS / site controller | Weak-grid, islanding, or resilience mode request | Grid-following -> grid-forming only under approved conditions | Mode logic, simulation, functional test | Not started |
+| Grid-forming to grid-following | Site controller / operator | Resynchronization with stable grid | Grid-forming -> synchronized grid-following | Sync record, protection review | Not started |
+| Any mode to fault | PCS / protection | Protection trip, internal fault, or unsafe condition | Immediate stop or controlled ramp-down as designed | Trip matrix, event log | Not started |
+| Fault to standby | Protection / operator | Fault cleared and reset approved | Fault -> standby only after reset criteria | Reset procedure, alarm log | Not started |
+
+## Review Prompts
+
+- Which system owns the command for each transition?
+- Is the transition automatic, operator-confirmed, or blocked by protection logic?
+- What evidence proves the transition under project grid conditions?
+- Are mode changes visible in SCADA or event logs?
+- Does the operator know which transitions are allowed during maintenance, outage, or emergency conditions?


### PR DESCRIPTION
## Summary
- add an inverter mode transition checklist
- cover transitions across standby, grid-following, grid-forming, and fault states
- link the checklist from the README

Closes #19.

## Validation
- git diff --check