### PR TITLE
Add grid service evidence checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 - [Storage glossary](glossary/storage-glossary.md)
 - [BESS control flow](diagrams/bess-control-flow.md)
 - [Grid support service comparison](concepts/grid-support-service-comparison.md)
+- [Grid service evidence checklist](checklists/grid-service-evidence-checklist.md)
 
 ## Repository Topics
 
@@ -50,3 +51,4 @@ LICENSE
 - Improve the BESS control-flow diagram notes.
 - Add project-specific inverter mode transition examples.
 - Add project-specific grid support service examples.
+- Add project-specific examples to the grid service evidence checklist.

--- a/checklists/grid-service-evidence-checklist.md
+++ b/checklists/grid-service-evidence-checklist.md
@@ -1,0 +1,18 @@
+# Grid Service Evidence Checklist
+
+Use this checklist to confirm that each proposed grid service has traceable settings, tests, and operating limits.
+
+| Evidence Area | Review Question | Evidence To Request |
+|---|---|---|
+| Service definition | Which grid service or operating outcome is being claimed? | Service name, use-case boundary, and operating mode |
+| Control settings | Which setpoint, threshold, droop, or priority drives the response? | PCS/EMS settings, control narrative, and revision ID |
+| Operating limits | Which SOC, power, reactive capability, warranty, or grid-code limit applies? | Capability curve, SOC rule, warranty note, or grid-code clause |
+| Test result | What proves the service was exercised? | Test case, event log, trend, timestamp, and pass criteria |
+| Operator handover | What should operators monitor after the service is enabled? | Alarm list, dashboard, escalation path, and owner |
+
+## Review Prompts
+
+- Which service takes priority if multiple controls request different setpoints?
+- Does the evidence show field testing, simulation, or configuration only?
+- What would satisfy the interconnection reviewer or system operator?
+- Which assumption should be revisited after the first operating event?


### PR DESCRIPTION
## Summary
- Add a grid service evidence checklist for service definition, control settings, limits, test results, and operator handover.
- Link the checklist from the README starter pages and contribution entry points.

Closes #23

## Validation
- git diff --check
