### PR TITLE
Add storage dispatch priority matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 - [Grid support service comparison](concepts/grid-support-service-comparison.md)
 - [Grid service evidence checklist](checklists/grid-service-evidence-checklist.md)
 
+- [Storage Dispatch Priority Matrix](concepts/storage-dispatch-priority-matrix.md)
+
 ## Repository Topics
 
 ```text
@@ -52,3 +54,4 @@ LICENSE
 - Add project-specific inverter mode transition examples.
 - Add project-specific grid support service examples.
 - Add project-specific examples to the grid service evidence checklist.
+- Add project-specific examples to the storage dispatch priority matrix.

--- a/concepts/storage-dispatch-priority-matrix.md
+++ b/concepts/storage-dispatch-priority-matrix.md
@@ -1,0 +1,18 @@
+# Storage Dispatch Priority Matrix
+
+Use this page for ordering control objectives when storage services compete for the same power or energy headroom. It keeps smart-grid storage discussions tied to service intent, control behavior, evidence, and operating limits.
+
+| Review Area | Prompt | Evidence To Request |
+|---|---|---|
+| Service intent | Which grid service, operating mode, or reliability outcome is being claimed? | State the service and use-case boundary. |
+| Control behavior | What setpoint, priority, threshold, or mode change drives the behavior? | Request settings, control notes, or event records. |
+| Limits | Which SOC, power, reactive capability, warranty, or grid-code limit applies? | Link limits and responsible owner. |
+| Test evidence | What proves the behavior was tested rather than only configured? | Capture test case, pass criteria, and result. |
+| Operations | What should operators monitor or escalate? | List alarms, dashboards, and handover notes. |
+
+## Review Prompts
+
+- Does the claim require grid-forming behavior, grid-following behavior, or either mode?
+- Which service takes priority during constrained operation?
+- What evidence would satisfy the system operator or interconnection reviewer?
+- Which assumption should be revisited after the first operating event?


### PR DESCRIPTION
## Summary
- Add Storage Dispatch Priority Matrix for ordering control objectives when storage services compete for the same power or energy headroom.
- Link the artifact from the repository index.

Closes #25

## Validation
- git diff --check
