### PR TITLE
Add grid forming test scenario log

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 
 - [Interconnection Review Questions](concepts/interconnection-review-questions.md)
 
+- [Grid Forming Test Scenario Log](concepts/grid-forming-test-scenario-log.md)
+
 ## Repository Topics
 
 ```text
@@ -58,3 +60,4 @@ LICENSE
 - Add project-specific examples to the grid service evidence checklist.
 - Add project-specific examples to the storage dispatch priority matrix.
 - Add project-specific examples to the interconnection review questions.
+- Add project-specific examples to the grid forming test scenario log.

--- a/concepts/grid-forming-test-scenario-log.md
+++ b/concepts/grid-forming-test-scenario-log.md
@@ -1,0 +1,18 @@
+# Grid Forming Test Scenario Log
+
+Use this page for tracking grid-forming test cases, pass criteria, and missing evidence. It keeps smart-grid storage discussions tied to service intent, control behavior, evidence, and operating limits.
+
+| Review Area | Prompt | Evidence To Request |
+|---|---|---|
+| Service intent | Which grid service, operating mode, or reliability outcome is being claimed? | State the service and use-case boundary. |
+| Control behavior | What setpoint, priority, threshold, or mode change drives the behavior? | Request settings, control notes, or event records. |
+| Limits | Which SOC, power, reactive capability, warranty, or grid-code limit applies? | Link limits and responsible owner. |
+| Test evidence | What proves the behavior was tested rather than only configured? | Capture test case, pass criteria, and result. |
+| Operations | What should operators monitor or escalate? | List alarms, dashboards, and handover notes. |
+
+## Review Prompts
+
+- Does the claim require grid-forming behavior, grid-following behavior, or either mode?
+- Which service takes priority during constrained operation?
+- What evidence would satisfy the system operator or interconnection reviewer?
+- Which assumption should be revisited after the first operating event?


### PR DESCRIPTION
## Summary
- Add Grid Forming Test Scenario Log for tracking grid-forming test cases, pass criteria, and missing evidence.
- Link the artifact from the repository index.

Closes #29

## Validation
- git diff --check
