### PR TITLE
Add resilience use case template

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 
 - [Grid Forming Test Scenario Log](concepts/grid-forming-test-scenario-log.md)
 
+- [Resilience Use Case Template](concepts/resilience-use-case-template.md)
+
 ## Repository Topics
 
 ```text
@@ -61,3 +63,4 @@ LICENSE
 - Add project-specific examples to the storage dispatch priority matrix.
 - Add project-specific examples to the interconnection review questions.
 - Add project-specific examples to the grid forming test scenario log.
+- Add project-specific examples to the resilience use case template.

--- a/concepts/resilience-use-case-template.md
+++ b/concepts/resilience-use-case-template.md
@@ -1,0 +1,18 @@
+# Resilience Use Case Template
+
+Use this page for defining the load, outage, SOC, and recovery assumptions behind resilience claims. It keeps smart-grid storage discussions tied to service intent, control behavior, evidence, and operating limits.
+
+| Review Area | Prompt | Evidence To Request |
+|---|---|---|
+| Service intent | Which grid service, operating mode, or reliability outcome is being claimed? | State the service and use-case boundary. |
+| Control behavior | What setpoint, priority, threshold, or mode change drives the behavior? | Request settings, control notes, or event records. |
+| Limits | Which SOC, power, reactive capability, warranty, or grid-code limit applies? | Link limits and responsible owner. |
+| Test evidence | What proves the behavior was tested rather than only configured? | Capture test case, pass criteria, and result. |
+| Operations | What should operators monitor or escalate? | List alarms, dashboards, and handover notes. |
+
+## Review Prompts
+
+- Does the claim require grid-forming behavior, grid-following behavior, or either mode?
+- Which service takes priority during constrained operation?
+- What evidence would satisfy the system operator or interconnection reviewer?
+- Which assumption should be revisited after the first operating event?


### PR DESCRIPTION
## Summary
- Add Resilience Use Case Template for defining the load, outage, SOC, and recovery assumptions behind resilience claims.
- Link the artifact from the repository index.

Closes #31

## Validation
- git diff --check
