### PR TITLE
Add renewable smoothing case note

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 
 - [Resilience Use Case Template](concepts/resilience-use-case-template.md)
 
+- [Renewable Smoothing Case Note](concepts/renewable-smoothing-case-note.md)
+
 ## Repository Topics
 
 ```text
@@ -64,3 +66,4 @@ LICENSE
 - Add project-specific examples to the interconnection review questions.
 - Add project-specific examples to the grid forming test scenario log.
 - Add project-specific examples to the resilience use case template.
+- Add project-specific examples to the renewable smoothing case note.

--- a/concepts/renewable-smoothing-case-note.md
+++ b/concepts/renewable-smoothing-case-note.md
@@ -1,0 +1,18 @@
+# Renewable Smoothing Case Note
+
+Use this page for documenting dispatch assumptions for using storage to smooth renewable generation ramps. It keeps smart-grid storage discussions tied to service intent, control behavior, evidence, and operating limits.
+
+| Review Area | Prompt | Evidence To Request |
+|---|---|---|
+| Service intent | Which grid service, operating mode, or reliability outcome is being claimed? | State the service and use-case boundary. |
+| Control behavior | What setpoint, priority, threshold, or mode change drives the behavior? | Request settings, control notes, or event records. |
+| Limits | Which SOC, power, reactive capability, warranty, or grid-code limit applies? | Link limits and responsible owner. |
+| Test evidence | What proves the behavior was tested rather than only configured? | Capture test case, pass criteria, and result. |
+| Operations | What should operators monitor or escalate? | List alarms, dashboards, and handover notes. |
+
+## Review Prompts
+
+- Does the claim require grid-forming behavior, grid-following behavior, or either mode?
+- Which service takes priority during constrained operation?
+- What evidence would satisfy the system operator or interconnection reviewer?
+- Which assumption should be revisited after the first operating event?


### PR DESCRIPTION
## Summary
- Add Renewable Smoothing Case Note for documenting dispatch assumptions for using storage to smooth renewable generation ramps.
- Link the artifact from the repository index.

Closes #33

## Validation
- git diff --check
