### PR TITLE
Add black start readiness prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 
 - [Protection Coordination Review](checklists/protection-coordination-review.md)
 
+- [Black Start Readiness Prompts](concepts/black-start-readiness-prompts.md)
+
 ## Repository Topics
 
 ```text
@@ -73,3 +75,4 @@ LICENSE
 - Add project-specific examples to the renewable smoothing case note.
 - Add project-specific examples to the active reactive power priority.
 - Add project-specific examples to the protection coordination review.
+- Add project-specific examples to the black start readiness prompts.

--- a/concepts/black-start-readiness-prompts.md
+++ b/concepts/black-start-readiness-prompts.md
@@ -1,0 +1,18 @@
+# Black Start Readiness Prompts
+
+Use this page for framing evidence questions for storage-supported restoration and black-start discussions. It keeps smart-grid storage discussions tied to service intent, control behavior, evidence, and operating limits.
+
+| Review Area | Prompt | Evidence To Request |
+|---|---|---|
+| Service intent | Which grid service, operating mode, or reliability outcome is being claimed? | State the service and use-case boundary. |
+| Control behavior | What setpoint, priority, threshold, or mode change drives the behavior? | Request settings, control notes, or event records. |
+| Limits | Which SOC, power, reactive capability, warranty, or grid-code limit applies? | Link limits and responsible owner. |
+| Test evidence | What proves the behavior was tested rather than only configured? | Capture test case, pass criteria, and result. |
+| Operations | What should operators monitor or escalate? | List alarms, dashboards, and handover notes. |
+
+## Review Prompts
+
+- Does the claim require grid-forming behavior, grid-following behavior, or either mode?
+- Which service takes priority during constrained operation?
+- What evidence would satisfy the system operator or interconnection reviewer?
+- Which assumption should be revisited after the first operating event?


### PR DESCRIPTION
## Summary
- Add Black Start Readiness Prompts for framing evidence questions for storage-supported restoration and black-start discussions.
- Link the artifact from the repository index.

Closes #39

## Validation
- git diff --check
