### PR TITLE
Add microgrid mode transition log

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 
 - [Black Start Readiness Prompts](concepts/black-start-readiness-prompts.md)
 
+- [Microgrid Mode Transition Log](concepts/microgrid-mode-transition-log.md)
+
 ## Repository Topics
 
 ```text
@@ -76,3 +78,4 @@ LICENSE
 - Add project-specific examples to the active reactive power priority.
 - Add project-specific examples to the protection coordination review.
 - Add project-specific examples to the black start readiness prompts.
+- Add project-specific examples to the microgrid mode transition log.

--- a/concepts/microgrid-mode-transition-log.md
+++ b/concepts/microgrid-mode-transition-log.md
@@ -1,0 +1,18 @@
+# Microgrid Mode Transition Log
+
+Use this page for tracking mode transitions between grid-connected, islanded, and recovery operation. It keeps smart-grid storage discussions tied to service intent, control behavior, evidence, and operating limits.
+
+| Review Area | Prompt | Evidence To Request |
+|---|---|---|
+| Service intent | Which grid service, operating mode, or reliability outcome is being claimed? | State the service and use-case boundary. |
+| Control behavior | What setpoint, priority, threshold, or mode change drives the behavior? | Request settings, control notes, or event records. |
+| Limits | Which SOC, power, reactive capability, warranty, or grid-code limit applies? | Link limits and responsible owner. |
+| Test evidence | What proves the behavior was tested rather than only configured? | Capture test case, pass criteria, and result. |
+| Operations | What should operators monitor or escalate? | List alarms, dashboards, and handover notes. |
+
+## Review Prompts
+
+- Does the claim require grid-forming behavior, grid-following behavior, or either mode?
+- Which service takes priority during constrained operation?
+- What evidence would satisfy the system operator or interconnection reviewer?
+- Which assumption should be revisited after the first operating event?


### PR DESCRIPTION
## Summary
- Add Microgrid Mode Transition Log for tracking mode transitions between grid-connected, islanded, and recovery operation.
- Link the artifact from the repository index.

Closes #41

## Validation
- git diff --check
