### PR TITLE
Add grid code traceability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 
 - [Microgrid Mode Transition Log](concepts/microgrid-mode-transition-log.md)
 
+- [Grid Code Traceability Matrix](concepts/grid-code-traceability-matrix.md)
+
 ## Repository Topics
 
 ```text
@@ -79,3 +81,4 @@ LICENSE
 - Add project-specific examples to the protection coordination review.
 - Add project-specific examples to the black start readiness prompts.
 - Add project-specific examples to the microgrid mode transition log.
+- Add project-specific examples to the grid code traceability matrix.

--- a/concepts/grid-code-traceability-matrix.md
+++ b/concepts/grid-code-traceability-matrix.md
@@ -1,0 +1,18 @@
+# Grid Code Traceability Matrix
+
+Use this page for linking grid-code clauses to evidence, owners, and unresolved questions. It keeps smart-grid storage discussions tied to service intent, control behavior, evidence, and operating limits.
+
+| Review Area | Prompt | Evidence To Request |
+|---|---|---|
+| Service intent | Which grid service, operating mode, or reliability outcome is being claimed? | State the service and use-case boundary. |
+| Control behavior | What setpoint, priority, threshold, or mode change drives the behavior? | Request settings, control notes, or event records. |
+| Limits | Which SOC, power, reactive capability, warranty, or grid-code limit applies? | Link limits and responsible owner. |
+| Test evidence | What proves the behavior was tested rather than only configured? | Capture test case, pass criteria, and result. |
+| Operations | What should operators monitor or escalate? | List alarms, dashboards, and handover notes. |
+
+## Review Prompts
+
+- Does the claim require grid-forming behavior, grid-following behavior, or either mode?
+- Which service takes priority during constrained operation?
+- What evidence would satisfy the system operator or interconnection reviewer?
+- Which assumption should be revisited after the first operating event?


### PR DESCRIPTION
## Summary
- Add Grid Code Traceability Matrix for linking grid-code clauses to evidence, owners, and unresolved questions.
- Link the artifact from the repository index.

Closes #43

## Validation
- git diff --check
