### PR TITLE
Add operator control room handover

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 
 - [Grid Code Traceability Matrix](concepts/grid-code-traceability-matrix.md)
 
+- [Operator Control Room Handover](concepts/operator-control-room-handover.md)
+
 ## Repository Topics
 
 ```text
@@ -82,3 +84,4 @@ LICENSE
 - Add project-specific examples to the black start readiness prompts.
 - Add project-specific examples to the microgrid mode transition log.
 - Add project-specific examples to the grid code traceability matrix.
+- Add project-specific examples to the operator control room handover.

--- a/concepts/operator-control-room-handover.md
+++ b/concepts/operator-control-room-handover.md
@@ -1,0 +1,18 @@
+# Operator Control Room Handover
+
+Use this page for clarifying the monitoring, alarm, dispatch, and escalation details operators need. It keeps smart-grid storage discussions tied to service intent, control behavior, evidence, and operating limits.
+
+| Review Area | Prompt | Evidence To Request |
+|---|---|---|
+| Service intent | Which grid service, operating mode, or reliability outcome is being claimed? | State the service and use-case boundary. |
+| Control behavior | What setpoint, priority, threshold, or mode change drives the behavior? | Request settings, control notes, or event records. |
+| Limits | Which SOC, power, reactive capability, warranty, or grid-code limit applies? | Link limits and responsible owner. |
+| Test evidence | What proves the behavior was tested rather than only configured? | Capture test case, pass criteria, and result. |
+| Operations | What should operators monitor or escalate? | List alarms, dashboards, and handover notes. |
+
+## Review Prompts
+
+- Does the claim require grid-forming behavior, grid-following behavior, or either mode?
+- Which service takes priority during constrained operation?
+- What evidence would satisfy the system operator or interconnection reviewer?
+- Which assumption should be revisited after the first operating event?


### PR DESCRIPTION
## Summary
- Add Operator Control Room Handover for clarifying the monitoring, alarm, dispatch, and escalation details operators need.
- Link the artifact from the repository index.

Closes #45

## Validation
- git diff --check
