### PR TITLE
Add event log review guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 
 - [Operator Control Room Handover](concepts/operator-control-room-handover.md)
 
+- [Event Log Review Guide](concepts/event-log-review-guide.md)
+
 ## Repository Topics
 
 ```text
@@ -85,3 +87,4 @@ LICENSE
 - Add project-specific examples to the microgrid mode transition log.
 - Add project-specific examples to the grid code traceability matrix.
 - Add project-specific examples to the operator control room handover.
+- Add project-specific examples to the event log review guide.

--- a/concepts/event-log-review-guide.md
+++ b/concepts/event-log-review-guide.md
@@ -1,0 +1,18 @@
+# Event Log Review Guide
+
+Use this page for reviewing storage controller and inverter event logs after grid-service tests. It keeps smart-grid storage discussions tied to service intent, control behavior, evidence, and operating limits.
+
+| Review Area | Prompt | Evidence To Request |
+|---|---|---|
+| Service intent | Which grid service, operating mode, or reliability outcome is being claimed? | State the service and use-case boundary. |
+| Control behavior | What setpoint, priority, threshold, or mode change drives the behavior? | Request settings, control notes, or event records. |
+| Limits | Which SOC, power, reactive capability, warranty, or grid-code limit applies? | Link limits and responsible owner. |
+| Test evidence | What proves the behavior was tested rather than only configured? | Capture test case, pass criteria, and result. |
+| Operations | What should operators monitor or escalate? | List alarms, dashboards, and handover notes. |
+
+## Review Prompts
+
+- Does the claim require grid-forming behavior, grid-following behavior, or either mode?
+- Which service takes priority during constrained operation?
+- What evidence would satisfy the system operator or interconnection reviewer?
+- Which assumption should be revisited after the first operating event?


### PR DESCRIPTION
## Summary
- Add Event Log Review Guide for reviewing storage controller and inverter event logs after grid-service tests.
- Link the artifact from the repository index.

Closes #47

## Validation
- git diff --check
