### PR TITLE
Add congestion relief dispatch note

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 
 - [Event Log Review Guide](concepts/event-log-review-guide.md)
 
+- [Congestion Relief Dispatch Note](concepts/congestion-relief-dispatch-note.md)
+
 ## Repository Topics
 
 ```text
@@ -88,3 +90,4 @@ LICENSE
 - Add project-specific examples to the grid code traceability matrix.
 - Add project-specific examples to the operator control room handover.
 - Add project-specific examples to the event log review guide.
+- Add project-specific examples to the congestion relief dispatch note.

--- a/concepts/congestion-relief-dispatch-note.md
+++ b/concepts/congestion-relief-dispatch-note.md
@@ -1,0 +1,18 @@
+# Congestion Relief Dispatch Note
+
+Use this page for describing how storage dispatch assumptions support congestion relief claims. It keeps smart-grid storage discussions tied to service intent, control behavior, evidence, and operating limits.
+
+| Review Area | Prompt | Evidence To Request |
+|---|---|---|
+| Service intent | Which grid service, operating mode, or reliability outcome is being claimed? | State the service and use-case boundary. |
+| Control behavior | What setpoint, priority, threshold, or mode change drives the behavior? | Request settings, control notes, or event records. |
+| Limits | Which SOC, power, reactive capability, warranty, or grid-code limit applies? | Link limits and responsible owner. |
+| Test evidence | What proves the behavior was tested rather than only configured? | Capture test case, pass criteria, and result. |
+| Operations | What should operators monitor or escalate? | List alarms, dashboards, and handover notes. |
+
+## Review Prompts
+
+- Does the claim require grid-forming behavior, grid-following behavior, or either mode?
+- Which service takes priority during constrained operation?
+- What evidence would satisfy the system operator or interconnection reviewer?
+- Which assumption should be revisited after the first operating event?


### PR DESCRIPTION
## Summary
- Add Congestion Relief Dispatch Note for describing how storage dispatch assumptions support congestion relief claims.
- Link the artifact from the repository index.

Closes #49

## Validation
- git diff --check
