### PR TITLE
Add market service assumption register

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 
 - [Congestion Relief Dispatch Note](concepts/congestion-relief-dispatch-note.md)
 
+- [Market Service Assumption Register](concepts/market-service-assumption-register.md)
+
 ## Repository Topics
 
 ```text
@@ -91,3 +93,4 @@ LICENSE
 - Add project-specific examples to the operator control room handover.
 - Add project-specific examples to the event log review guide.
 - Add project-specific examples to the congestion relief dispatch note.
+- Add project-specific examples to the market service assumption register.

--- a/concepts/market-service-assumption-register.md
+++ b/concepts/market-service-assumption-register.md
@@ -1,0 +1,18 @@
+# Market Service Assumption Register
+
+Use this page for separating market-service assumptions from technical grid-service evidence. It keeps smart-grid storage discussions tied to service intent, control behavior, evidence, and operating limits.
+
+| Review Area | Prompt | Evidence To Request |
+|---|---|---|
+| Service intent | Which grid service, operating mode, or reliability outcome is being claimed? | State the service and use-case boundary. |
+| Control behavior | What setpoint, priority, threshold, or mode change drives the behavior? | Request settings, control notes, or event records. |
+| Limits | Which SOC, power, reactive capability, warranty, or grid-code limit applies? | Link limits and responsible owner. |
+| Test evidence | What proves the behavior was tested rather than only configured? | Capture test case, pass criteria, and result. |
+| Operations | What should operators monitor or escalate? | List alarms, dashboards, and handover notes. |
+
+## Review Prompts
+
+- Does the claim require grid-forming behavior, grid-following behavior, or either mode?
+- Which service takes priority during constrained operation?
+- What evidence would satisfy the system operator or interconnection reviewer?
+- Which assumption should be revisited after the first operating event?


### PR DESCRIPTION
## Summary
- Add Market Service Assumption Register for separating market-service assumptions from technical grid-service evidence.
- Link the artifact from the repository index.

Closes #51

## Validation
- git diff --check
