### PR TITLE
Add availability performance template

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 
 - [Harmonic Performance Evidence](concepts/harmonic-performance-evidence.md)
 
+- [Availability Performance Template](concepts/availability-performance-template.md)
+
 ## Repository Topics
 
 ```text
@@ -100,3 +102,4 @@ LICENSE
 - Add project-specific examples to the market service assumption register.
 - Add project-specific examples to the islanding risk review checklist.
 - Add project-specific examples to the harmonic performance evidence.
+- Add project-specific examples to the availability performance template.

--- a/concepts/availability-performance-template.md
+++ b/concepts/availability-performance-template.md
@@ -1,0 +1,18 @@
+# Availability Performance Template
+
+Use this page for capturing storage availability assumptions, exclusions, and supporting event evidence. It keeps smart-grid storage discussions tied to service intent, control behavior, evidence, and operating limits.
+
+| Review Area | Prompt | Evidence To Request |
+|---|---|---|
+| Service intent | Which grid service, operating mode, or reliability outcome is being claimed? | State the service and use-case boundary. |
+| Control behavior | What setpoint, priority, threshold, or mode change drives the behavior? | Request settings, control notes, or event records. |
+| Limits | Which SOC, power, reactive capability, warranty, or grid-code limit applies? | Link limits and responsible owner. |
+| Test evidence | What proves the behavior was tested rather than only configured? | Capture test case, pass criteria, and result. |
+| Operations | What should operators monitor or escalate? | List alarms, dashboards, and handover notes. |
+
+## Review Prompts
+
+- Does the claim require grid-forming behavior, grid-following behavior, or either mode?
+- Which service takes priority during constrained operation?
+- What evidence would satisfy the system operator or interconnection reviewer?
+- Which assumption should be revisited after the first operating event?


### PR DESCRIPTION
## Summary
- Add Availability Performance Template for capturing storage availability assumptions, exclusions, and supporting event evidence.
- Link the artifact from the repository index.

Closes #57

## Validation
- git diff --check
