### PR TITLE
Add service stacking conflict log

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 
 - [Availability Performance Template](concepts/availability-performance-template.md)
 
+- [Service Stacking Conflict Log](concepts/service-stacking-conflict-log.md)
+
 ## Repository Topics
 
 ```text
@@ -103,3 +105,4 @@ LICENSE
 - Add project-specific examples to the islanding risk review checklist.
 - Add project-specific examples to the harmonic performance evidence.
 - Add project-specific examples to the availability performance template.
+- Add project-specific examples to the service stacking conflict log.

--- a/concepts/service-stacking-conflict-log.md
+++ b/concepts/service-stacking-conflict-log.md
@@ -1,0 +1,18 @@
+# Service Stacking Conflict Log
+
+Use this page for recording conflicts when multiple grid services compete for storage capability. It keeps smart-grid storage discussions tied to service intent, control behavior, evidence, and operating limits.
+
+| Review Area | Prompt | Evidence To Request |
+|---|---|---|
+| Service intent | Which grid service, operating mode, or reliability outcome is being claimed? | State the service and use-case boundary. |
+| Control behavior | What setpoint, priority, threshold, or mode change drives the behavior? | Request settings, control notes, or event records. |
+| Limits | Which SOC, power, reactive capability, warranty, or grid-code limit applies? | Link limits and responsible owner. |
+| Test evidence | What proves the behavior was tested rather than only configured? | Capture test case, pass criteria, and result. |
+| Operations | What should operators monitor or escalate? | List alarms, dashboards, and handover notes. |
+
+## Review Prompts
+
+- Does the claim require grid-forming behavior, grid-following behavior, or either mode?
+- Which service takes priority during constrained operation?
+- What evidence would satisfy the system operator or interconnection reviewer?
+- Which assumption should be revisited after the first operating event?


### PR DESCRIPTION
## Summary
- Add Service Stacking Conflict Log for recording conflicts when multiple grid services compete for storage capability.
- Link the artifact from the repository index.

Closes #59

## Validation
- git diff --check
