### PR TITLE
Add playbook next research questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 
 - [System Operator Query Log](concepts/system-operator-query-log.md)
 
+- [Playbook Next Research Questions](concepts/playbook-next-research-questions.md)
+
 ## Repository Topics
 
 ```text
@@ -109,3 +111,4 @@ LICENSE
 - Add project-specific examples to the availability performance template.
 - Add project-specific examples to the service stacking conflict log.
 - Add project-specific examples to the system operator query log.
+- Add project-specific examples to the playbook next research questions.

--- a/concepts/playbook-next-research-questions.md
+++ b/concepts/playbook-next-research-questions.md
@@ -1,0 +1,18 @@
+# Playbook Next Research Questions
+
+Use this page for capturing unanswered smart-grid storage questions for future source-backed expansion. It keeps smart-grid storage discussions tied to service intent, control behavior, evidence, and operating limits.
+
+| Review Area | Prompt | Evidence To Request |
+|---|---|---|
+| Service intent | Which grid service, operating mode, or reliability outcome is being claimed? | State the service and use-case boundary. |
+| Control behavior | What setpoint, priority, threshold, or mode change drives the behavior? | Request settings, control notes, or event records. |
+| Limits | Which SOC, power, reactive capability, warranty, or grid-code limit applies? | Link limits and responsible owner. |
+| Test evidence | What proves the behavior was tested rather than only configured? | Capture test case, pass criteria, and result. |
+| Operations | What should operators monitor or escalate? | List alarms, dashboards, and handover notes. |
+
+## Review Prompts
+
+- Does the claim require grid-forming behavior, grid-following behavior, or either mode?
+- Which service takes priority during constrained operation?
+- What evidence would satisfy the system operator or interconnection reviewer?
+- Which assumption should be revisited after the first operating event?


### PR DESCRIPTION
## Summary
- Add Playbook Next Research Questions for capturing unanswered smart-grid storage questions for future source-backed expansion.
- Link the artifact from the repository index.

Closes #63

## Validation
- git diff --check
