### PR TITLE
Add active reactive capability model

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -1,23 +1,40 @@
-name: Markdown maintenance
+name: Model and Markdown validation
 
 on:
   workflow_dispatch:
   pull_request:
     paths:
       - "**.md"
+      - "**.py"
+      - ".github/workflows/markdown-maintenance.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**.md"
+      - "**.py"
+      - ".github/workflows/markdown-maintenance.yml"
 
 permissions:
   contents: read
 
 jobs:
-  link-check:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Test executable models
+        run: python -m unittest discover -s tests -v
 
       - name: Check Markdown links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress README.md CONTRIBUTING.md concepts/*.md checklists/*.md glossary/*.md diagrams/*.md
+          args: --verbose --no-progress README.md CONTRIBUTING.md models/*.md concepts/*.md checklists/*.md glossary/*.md diagrams/*.md
           fail: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing
 
-Contributions should make smart-grid and storage concepts easier to inspect, teach, or reuse.
+Contributions should make smart-grid and storage concepts easier to inspect,
+teach, or reuse.
 
 ## Good Contributions
 
@@ -15,3 +16,4 @@ Contributions should make smart-grid and storage concepts easier to inspect, tea
 - [ ] Acronyms are defined.
 - [ ] Diagrams include alt text or descriptions.
 - [ ] Sources are public.
+- [ ] `python -m unittest discover -s tests -v` passes for model changes.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Smart Grid Storage Playbook
 
-[![Markdown maintenance](https://github.com/mohammadrezwankhan/smart-grid-storage-playbook/actions/workflows/markdown-maintenance.yml/badge.svg)](https://github.com/mohammadrezwankhan/smart-grid-storage-playbook/actions/workflows/markdown-maintenance.yml)
+[![Model and Markdown validation](https://github.com/mohammadrezwankhan/smart-grid-storage-playbook/actions/workflows/markdown-maintenance.yml/badge.svg)](https://github.com/mohammadrezwankhan/smart-grid-storage-playbook/actions/workflows/markdown-maintenance.yml)
 
-Explainable smart-grid and grid-forming BESS concepts for engineers, students, and project teams.
+Explainable smart-grid and grid-forming BESS concepts for engineers, students,
+and project teams.
 
 ## What This Covers
 
@@ -13,6 +14,8 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 - Technical diagrams and plain-English explainers.
 
 ## Starter Pages
+
+- [Executable active/reactive capability reference](models/README.md)
 
 - [Grid-forming vs grid-following storage](concepts/grid-forming-vs-grid-following.md)
 - [Grid-code evidence prompt](concepts/grid-code-evidence-prompt.md)
@@ -67,7 +70,8 @@ Explainable smart-grid and grid-forming BESS concepts for engineers, students, a
 ## Repository Topics
 
 ```text
-smart-grid grid-forming energy-storage renewable-integration power-systems bess technical-writing
+smart-grid grid-forming energy-storage renewable-integration
+power-systems bess technical-writing
 ```
 
 ## Planned Sections
@@ -82,6 +86,20 @@ README.md
 CONTRIBUTING.md
 LICENSE
 ```
+
+## Run The Executable Reference
+
+The dependency-free allocator demonstrates active-priority, reactive-priority,
+and proportional handling of commands outside a circular MVA limit:
+
+```powershell
+python models/pq_capability.py `
+  --active-mw 80 --reactive-mvar 80 --limit-mva 100 --priority active
+python -m unittest discover -s tests -v
+```
+
+Review the [model assumptions and limitations](models/README.md) before mapping
+the result to a plant controller, PCS capability curve, or grid-code study.
 
 ## Contribution Entry Points
 

--- a/concepts/active-reactive-power-priority.md
+++ b/concepts/active-reactive-power-priority.md
@@ -1,18 +1,32 @@
 # Active Reactive Power Priority
 
-Use this page for explaining how active and reactive power commands should be prioritized during constrained operation. It keeps smart-grid storage discussions tied to service intent, control behavior, evidence, and operating limits.
+Use this page for explaining how active and reactive power commands should be
+prioritized during constrained operation. It keeps smart-grid storage discussions
+tied to service intent, control behavior, evidence, and operating limits.
+
+<!-- markdownlint-disable MD013 -->
 
 | Review Area | Prompt | Evidence To Request |
-|---|---|---|
+| --- | --- | --- |
 | Service intent | Which grid service, operating mode, or reliability outcome is being claimed? | State the service and use-case boundary. |
 | Control behavior | What setpoint, priority, threshold, or mode change drives the behavior? | Request settings, control notes, or event records. |
 | Limits | Which SOC, power, reactive capability, warranty, or grid-code limit applies? | Link limits and responsible owner. |
 | Test evidence | What proves the behavior was tested rather than only configured? | Capture test case, pass criteria, and result. |
 | Operations | What should operators monitor or escalate? | List alarms, dashboards, and handover notes. |
 
+<!-- markdownlint-enable MD013 -->
+
 ## Review Prompts
 
-- Does the claim require grid-forming behavior, grid-following behavior, or either mode?
+- Does the claim require grid-forming behavior, grid-following behavior, or either
+  mode?
 - Which service takes priority during constrained operation?
 - What evidence would satisfy the system operator or interconnection reviewer?
 - Which assumption should be revisited after the first operating event?
+
+## Executable Reference
+
+The [active/reactive capability model](../models/README.md) provides a small,
+testable example of active-priority, reactive-priority, and proportional
+curtailment under a circular MVA limit. It is an educational allocator, not a
+replacement for the project's manufacturer capability curve or control model.

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,57 @@
+# Active/Reactive Capability Reference
+
+This dependency-free Python example makes constrained active/reactive power
+priority explicit. It applies a circular inverter capability limit and reports
+the delivered command, curtailed command, apparent power, and utilization.
+
+## Capability Rule
+
+The requested command is feasible when:
+
+```text
+sqrt(P^2 + Q^2) <= S_limit
+```
+
+When the request is outside that circle, the selected policy behaves as
+follows:
+
+- `active`: preserve active power first and use remaining MVA headroom for
+  reactive power;
+- `reactive`: preserve reactive power first and use remaining headroom for
+  active power; or
+- `proportional`: scale active and reactive power by the same factor.
+
+## Run A Constrained Example
+
+```powershell
+python models/pq_capability.py `
+  --active-mw 80 `
+  --reactive-mvar 80 `
+  --limit-mva 100 `
+  --priority active
+```
+
+Expected delivered command:
+
+```text
+Active power: 80.000 MW
+Reactive power: 60.000 MVAr
+Apparent power: 100.000 MVA
+Capability utilization: 100.00%
+```
+
+Run the regression checks with:
+
+```powershell
+python -m unittest discover -s tests -v
+```
+
+## Explicit Limitations
+
+- The capability boundary is a fixed circle rather than a manufacturer curve.
+- Dynamic current limits, voltage dependence, temperature derating, SOC, and
+  duration limits are excluded.
+- The allocator is static and does not model control-loop response.
+- Grid-code, protection, and plant-controller constraints remain project
+  inputs.
+- Sign conventions must be aligned with the target EMS, PCS, and study model.

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,1 @@
+"""Executable reference models for the smart-grid storage playbook."""

--- a/models/pq_capability.py
+++ b/models/pq_capability.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass
+from enum import Enum
+
+
+class PowerPriority(str, Enum):
+    ACTIVE = "active"
+    REACTIVE = "reactive"
+    PROPORTIONAL = "proportional"
+
+
+@dataclass(frozen=True)
+class CapabilityResult:
+    requested_active_mw: float
+    requested_reactive_mvar: float
+    active_mw: float
+    reactive_mvar: float
+    apparent_power_mva: float
+    utilization: float
+    curtailed_active_mw: float
+    curtailed_reactive_mvar: float
+    limited: bool
+    priority: PowerPriority
+
+
+def _clip(value: float, limit: float) -> float:
+    return max(-limit, min(limit, value))
+
+
+def allocate_power(
+    requested_active_mw: float,
+    requested_reactive_mvar: float,
+    apparent_power_limit_mva: float,
+    priority: PowerPriority | str = PowerPriority.ACTIVE,
+) -> CapabilityResult:
+    """Apply a circular P-Q capability limit using the selected priority."""
+
+    values = {
+        "requested_active_mw": requested_active_mw,
+        "requested_reactive_mvar": requested_reactive_mvar,
+        "apparent_power_limit_mva": apparent_power_limit_mva,
+    }
+    for name, value in values.items():
+        if not math.isfinite(value):
+            raise ValueError(f"{name} must be finite")
+    if apparent_power_limit_mva <= 0.0:
+        raise ValueError("apparent_power_limit_mva must be positive")
+
+    try:
+        selected_priority = PowerPriority(priority)
+    except ValueError as error:
+        choices = ", ".join(item.value for item in PowerPriority)
+        raise ValueError(f"priority must be one of: {choices}") from error
+
+    requested_mva = math.hypot(
+        requested_active_mw,
+        requested_reactive_mvar,
+    )
+    if requested_mva <= apparent_power_limit_mva:
+        active_mw = requested_active_mw
+        reactive_mvar = requested_reactive_mvar
+    elif selected_priority is PowerPriority.ACTIVE:
+        active_mw = _clip(requested_active_mw, apparent_power_limit_mva)
+        reactive_limit = math.sqrt(
+            max(0.0, apparent_power_limit_mva**2 - active_mw**2)
+        )
+        reactive_mvar = _clip(requested_reactive_mvar, reactive_limit)
+    elif selected_priority is PowerPriority.REACTIVE:
+        reactive_mvar = _clip(
+            requested_reactive_mvar,
+            apparent_power_limit_mva,
+        )
+        active_limit = math.sqrt(
+            max(0.0, apparent_power_limit_mva**2 - reactive_mvar**2)
+        )
+        active_mw = _clip(requested_active_mw, active_limit)
+    else:
+        scale = apparent_power_limit_mva / requested_mva
+        active_mw = requested_active_mw * scale
+        reactive_mvar = requested_reactive_mvar * scale
+
+    apparent_power_mva = math.hypot(active_mw, reactive_mvar)
+    active_curtailment = requested_active_mw - active_mw
+    reactive_curtailment = requested_reactive_mvar - reactive_mvar
+    limited = not (
+        math.isclose(active_curtailment, 0.0, rel_tol=0.0, abs_tol=1e-12)
+        and math.isclose(reactive_curtailment, 0.0, rel_tol=0.0, abs_tol=1e-12)
+    )
+
+    return CapabilityResult(
+        requested_active_mw=requested_active_mw,
+        requested_reactive_mvar=requested_reactive_mvar,
+        active_mw=active_mw,
+        reactive_mvar=reactive_mvar,
+        apparent_power_mva=apparent_power_mva,
+        utilization=apparent_power_mva / apparent_power_limit_mva,
+        curtailed_active_mw=active_curtailment,
+        curtailed_reactive_mvar=reactive_curtailment,
+        limited=limited,
+        priority=selected_priority,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Apply a circular inverter P-Q capability limit."
+    )
+    parser.add_argument("--active-mw", type=float, required=True)
+    parser.add_argument("--reactive-mvar", type=float, required=True)
+    parser.add_argument("--limit-mva", type=float, required=True)
+    parser.add_argument(
+        "--priority",
+        choices=[item.value for item in PowerPriority],
+        default=PowerPriority.ACTIVE.value,
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    result = allocate_power(
+        args.active_mw,
+        args.reactive_mvar,
+        args.limit_mva,
+        args.priority,
+    )
+    print(f"Priority: {result.priority.value}")
+    print(f"Limited: {str(result.limited).lower()}")
+    print(f"Active power: {result.active_mw:.3f} MW")
+    print(f"Reactive power: {result.reactive_mvar:.3f} MVAr")
+    print(f"Apparent power: {result.apparent_power_mva:.3f} MVA")
+    print(f"Capability utilization: {100.0 * result.utilization:.2f}%")
+    print(f"Active curtailment: {result.curtailed_active_mw:.3f} MW")
+    print(
+        "Reactive curtailment: "
+        f"{result.curtailed_reactive_mvar:.3f} MVAr"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pq_capability.py
+++ b/tests/test_pq_capability.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import math
+import unittest
+
+from models.pq_capability import PowerPriority, allocate_power
+
+
+class PqCapabilityTests(unittest.TestCase):
+    def test_feasible_request_passes_through(self):
+        result = allocate_power(60.0, 40.0, 100.0)
+        self.assertEqual(result.active_mw, 60.0)
+        self.assertEqual(result.reactive_mvar, 40.0)
+        self.assertFalse(result.limited)
+        self.assertLess(result.utilization, 1.0)
+
+    def test_active_priority_preserves_active_command(self):
+        result = allocate_power(80.0, 80.0, 100.0, PowerPriority.ACTIVE)
+        self.assertAlmostEqual(result.active_mw, 80.0)
+        self.assertAlmostEqual(result.reactive_mvar, 60.0)
+        self.assertAlmostEqual(result.apparent_power_mva, 100.0)
+        self.assertTrue(result.limited)
+
+    def test_reactive_priority_preserves_reactive_command(self):
+        result = allocate_power(80.0, 80.0, 100.0, PowerPriority.REACTIVE)
+        self.assertAlmostEqual(result.active_mw, 60.0)
+        self.assertAlmostEqual(result.reactive_mvar, 80.0)
+        self.assertAlmostEqual(result.apparent_power_mva, 100.0)
+
+    def test_proportional_priority_preserves_command_ratio(self):
+        result = allocate_power(90.0, 120.0, 100.0, PowerPriority.PROPORTIONAL)
+        self.assertAlmostEqual(result.active_mw, 60.0)
+        self.assertAlmostEqual(result.reactive_mvar, 80.0)
+        self.assertAlmostEqual(result.active_mw / result.reactive_mvar, 0.75)
+
+    def test_single_axis_command_is_clipped(self):
+        result = allocate_power(150.0, 20.0, 100.0, PowerPriority.ACTIVE)
+        self.assertAlmostEqual(result.active_mw, 100.0)
+        self.assertAlmostEqual(result.reactive_mvar, 0.0)
+        self.assertAlmostEqual(result.apparent_power_mva, 100.0)
+
+    def test_negative_commands_preserve_quadrant(self):
+        result = allocate_power(-80.0, -80.0, 100.0, PowerPriority.ACTIVE)
+        self.assertAlmostEqual(result.active_mw, -80.0)
+        self.assertAlmostEqual(result.reactive_mvar, -60.0)
+        self.assertGreater(result.curtailed_active_mw, -1e-12)
+        self.assertLess(result.curtailed_reactive_mvar, 0.0)
+
+    def test_rejects_invalid_inputs(self):
+        with self.assertRaisesRegex(ValueError, "must be positive"):
+            allocate_power(10.0, 10.0, 0.0)
+        with self.assertRaisesRegex(ValueError, "must be finite"):
+            allocate_power(math.nan, 10.0, 100.0)
+        with self.assertRaisesRegex(ValueError, "priority must be one of"):
+            allocate_power(10.0, 10.0, 100.0, "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dependency-free circular P-Q capability allocator
- support active, reactive, and proportional priority policies
- add seven regression tests and run them in GitHub Actions
- document assumptions, limitations, and a reproducible CLI example

## Validation
- `python -m unittest discover -s tests -v`
- `python models/pq_capability.py --active-mw 80 --reactive-mvar 80 --limit-mva 100 --priority active`
- `npx --yes markdownlint-cli2 README.md CONTRIBUTING.md models/README.md concepts/active-reactive-power-priority.md`
- `npx --yes markdown-link-check <all repository Markdown files> --quiet`
- `npx --yes prettier --check .github/workflows/markdown-maintenance.yml`
- `git diff --check`