### PR TITLE
Add Volt VAR dispatch reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,3 +17,4 @@ teach, or reuse.
 - [ ] Diagrams include alt text or descriptions.
 - [ ] Sources are public.
 - [ ] `python -m unittest discover -s tests -v` passes for model changes.
+- [ ] Control breakpoints and sign conventions are documented.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ and project teams.
 ## Starter Pages
 
 - [Executable active/reactive capability reference](models/README.md)
+- [Executable Volt-VAR dispatch reference](models/README.md#volt-var-dispatch-reference)
 
 - [Grid-forming vs grid-following storage](concepts/grid-forming-vs-grid-following.md)
 - [Grid-code evidence prompt](concepts/grid-code-evidence-prompt.md)
@@ -95,6 +96,8 @@ and proportional handling of commands outside a circular MVA limit:
 ```powershell
 python models/pq_capability.py `
   --active-mw 80 --reactive-mvar 80 --limit-mva 100 --priority active
+python models/volt_var.py `
+  --voltage-pu 0.95 --active-mw 90 --limit-mva 100
 python -m unittest discover -s tests -v
 ```
 

--- a/models/README.md
+++ b/models/README.md
@@ -55,3 +55,46 @@ python -m unittest discover -s tests -v
 - Grid-code, protection, and plant-controller constraints remain project
   inputs.
 - Sign conventions must be aligned with the target EMS, PCS, and study model.
+
+## Volt-VAR Dispatch Reference
+
+[`volt_var.py`](volt_var.py) adds an illustrative four-breakpoint voltage
+support curve and sends its reactive-power request through the circular P-Q
+allocator. Positive reactive power means injection at low voltage; negative
+reactive power means absorption at high voltage.
+
+The default breakpoints are configurable educational values, not a claim about
+any grid code, inverter setting, or interconnection agreement:
+
+| Region | Default Behavior |
+| --- | --- |
+| `V <= 0.92 pu` | Saturate at `+1.0 pu` reactive request. |
+| `0.92 < V < 0.98 pu` | Ramp linearly from injection to zero. |
+| `0.98 <= V <= 1.02 pu` | Hold a zero-reactive-power deadband. |
+| `1.02 < V < 1.08 pu` | Ramp linearly from zero to absorption. |
+| `V >= 1.08 pu` | Saturate at `-1.0 pu` reactive request. |
+
+Run a low-voltage case where reactive-priority dispatch reduces active power to
+stay inside a 100 MVA limit:
+
+```powershell
+python models/volt_var.py `
+  --voltage-pu 0.95 `
+  --active-mw 90 `
+  --limit-mva 100
+```
+
+Expected key values:
+
+```text
+Volt-VAR request: 0.500 pu
+Requested reactive power: 50.000 MVAr
+Capability limited: true
+Delivered active power: 86.603 MW
+Delivered reactive power: 50.000 MVAr
+```
+
+Use `--priority active` to study the competing policy that preserves active
+power and curtails the reactive request instead. Replace all breakpoints,
+reactive base, priority, and capability assumptions with project-controlled
+settings before engineering use.

--- a/models/volt_var.py
+++ b/models/volt_var.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
+try:
+    from models.pq_capability import (
+        CapabilityResult,
+        PowerPriority,
+        allocate_power,
+    )
+except ModuleNotFoundError:
+    from pq_capability import CapabilityResult, PowerPriority, allocate_power
+
+
+@dataclass(frozen=True)
+class VoltVarCurve:
+    """Illustrative four-breakpoint voltage-to-reactive-power curve."""
+
+    low_saturation_pu: float = 0.92
+    low_deadband_pu: float = 0.98
+    high_deadband_pu: float = 1.02
+    high_saturation_pu: float = 1.08
+    max_reactive_power_pu: float = 1.0
+
+    def validate(self) -> None:
+        values = {
+            "low_saturation_pu": self.low_saturation_pu,
+            "low_deadband_pu": self.low_deadband_pu,
+            "high_deadband_pu": self.high_deadband_pu,
+            "high_saturation_pu": self.high_saturation_pu,
+            "max_reactive_power_pu": self.max_reactive_power_pu,
+        }
+        for name, value in values.items():
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+        if not (
+            0.0
+            < self.low_saturation_pu
+            < self.low_deadband_pu
+            <= 1.0
+            <= self.high_deadband_pu
+            < self.high_saturation_pu
+        ):
+            raise ValueError(
+                "voltage breakpoints must satisfy "
+                "0 < low saturation < low deadband <= 1 <= high deadband "
+                "< high saturation"
+            )
+        if self.max_reactive_power_pu <= 0.0:
+            raise ValueError("max_reactive_power_pu must be positive")
+
+    def reactive_request_pu(self, voltage_pu: float) -> float:
+        """Return positive Q injection at low voltage and absorption at high."""
+
+        self.validate()
+        if not math.isfinite(voltage_pu) or voltage_pu < 0.0:
+            raise ValueError("voltage_pu must be finite and nonnegative")
+        if voltage_pu <= self.low_saturation_pu:
+            return self.max_reactive_power_pu
+        if voltage_pu < self.low_deadband_pu:
+            fraction = (self.low_deadband_pu - voltage_pu) / (
+                self.low_deadband_pu - self.low_saturation_pu
+            )
+            return self.max_reactive_power_pu * fraction
+        if voltage_pu <= self.high_deadband_pu:
+            return 0.0
+        if voltage_pu < self.high_saturation_pu:
+            fraction = (voltage_pu - self.high_deadband_pu) / (
+                self.high_saturation_pu - self.high_deadband_pu
+            )
+            return -self.max_reactive_power_pu * fraction
+        return -self.max_reactive_power_pu
+
+
+@dataclass(frozen=True)
+class VoltVarDispatch:
+    voltage_pu: float
+    reactive_request_pu: float
+    requested_reactive_mvar: float
+    capability: CapabilityResult
+
+
+def dispatch_volt_var(
+    voltage_pu: float,
+    active_power_mw: float,
+    apparent_power_limit_mva: float,
+    reactive_base_mvar: float | None = None,
+    curve: VoltVarCurve = VoltVarCurve(),
+    priority: PowerPriority | str = PowerPriority.REACTIVE,
+) -> VoltVarDispatch:
+    """Evaluate a Volt-VAR request and enforce circular inverter capability."""
+
+    base_mvar = (
+        apparent_power_limit_mva if reactive_base_mvar is None else reactive_base_mvar
+    )
+    if not math.isfinite(base_mvar) or base_mvar <= 0.0:
+        raise ValueError("reactive_base_mvar must be finite and positive")
+    request_pu = curve.reactive_request_pu(voltage_pu)
+    requested_reactive_mvar = request_pu * base_mvar
+    capability = allocate_power(
+        active_power_mw,
+        requested_reactive_mvar,
+        apparent_power_limit_mva,
+        priority,
+    )
+    return VoltVarDispatch(
+        voltage_pu=voltage_pu,
+        reactive_request_pu=request_pu,
+        requested_reactive_mvar=requested_reactive_mvar,
+        capability=capability,
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate an illustrative Volt-VAR command and P-Q limit."
+    )
+    parser.add_argument("--voltage-pu", type=float, required=True)
+    parser.add_argument("--active-mw", type=float, required=True)
+    parser.add_argument("--limit-mva", type=float, required=True)
+    parser.add_argument("--reactive-base-mvar", type=float)
+    parser.add_argument(
+        "--priority",
+        choices=[item.value for item in PowerPriority],
+        default=PowerPriority.REACTIVE.value,
+    )
+    parser.add_argument("--low-saturation-pu", type=float, default=0.92)
+    parser.add_argument("--low-deadband-pu", type=float, default=0.98)
+    parser.add_argument("--high-deadband-pu", type=float, default=1.02)
+    parser.add_argument("--high-saturation-pu", type=float, default=1.08)
+    parser.add_argument("--max-reactive-power-pu", type=float, default=1.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    curve = VoltVarCurve(
+        low_saturation_pu=args.low_saturation_pu,
+        low_deadband_pu=args.low_deadband_pu,
+        high_deadband_pu=args.high_deadband_pu,
+        high_saturation_pu=args.high_saturation_pu,
+        max_reactive_power_pu=args.max_reactive_power_pu,
+    )
+    result = dispatch_volt_var(
+        voltage_pu=args.voltage_pu,
+        active_power_mw=args.active_mw,
+        apparent_power_limit_mva=args.limit_mva,
+        reactive_base_mvar=args.reactive_base_mvar,
+        curve=curve,
+        priority=args.priority,
+    )
+    capability = result.capability
+    print(f"Voltage: {result.voltage_pu:.3f} pu")
+    print(f"Volt-VAR request: {result.reactive_request_pu:.3f} pu")
+    print(f"Requested reactive power: {result.requested_reactive_mvar:.3f} MVAr")
+    print(f"Capability priority: {capability.priority.value}")
+    print(f"Capability limited: {str(capability.limited).lower()}")
+    print(f"Delivered active power: {capability.active_mw:.3f} MW")
+    print(f"Delivered reactive power: {capability.reactive_mvar:.3f} MVAr")
+    print(f"Delivered apparent power: {capability.apparent_power_mva:.3f} MVA")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_volt_var.py
+++ b/tests/test_volt_var.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import math
+import unittest
+
+from models.pq_capability import PowerPriority
+from models.volt_var import VoltVarCurve, dispatch_volt_var, main
+
+
+class VoltVarTests(unittest.TestCase):
+    def test_curve_saturates_at_low_and_high_voltage(self):
+        curve = VoltVarCurve()
+        self.assertEqual(curve.reactive_request_pu(0.80), 1.0)
+        self.assertEqual(curve.reactive_request_pu(0.92), 1.0)
+        self.assertEqual(curve.reactive_request_pu(1.08), -1.0)
+        self.assertEqual(curve.reactive_request_pu(1.20), -1.0)
+
+    def test_curve_interpolates_and_has_a_deadband(self):
+        curve = VoltVarCurve()
+        self.assertAlmostEqual(curve.reactive_request_pu(0.95), 0.5)
+        self.assertEqual(curve.reactive_request_pu(1.0), 0.0)
+        self.assertAlmostEqual(curve.reactive_request_pu(1.05), -0.5)
+
+    def test_curve_rejects_invalid_breakpoints_and_voltage(self):
+        with self.assertRaisesRegex(ValueError, "voltage breakpoints"):
+            VoltVarCurve(low_deadband_pu=0.90).reactive_request_pu(1.0)
+        with self.assertRaisesRegex(ValueError, "finite and nonnegative"):
+            VoltVarCurve().reactive_request_pu(math.nan)
+        with self.assertRaisesRegex(ValueError, "must be positive"):
+            VoltVarCurve(max_reactive_power_pu=0.0).reactive_request_pu(1.0)
+
+    def test_feasible_request_passes_through_capability(self):
+        result = dispatch_volt_var(0.95, 60.0, 100.0)
+        self.assertAlmostEqual(result.requested_reactive_mvar, 50.0)
+        self.assertAlmostEqual(result.capability.active_mw, 60.0)
+        self.assertAlmostEqual(result.capability.reactive_mvar, 50.0)
+        self.assertFalse(result.capability.limited)
+
+    def test_reactive_priority_preserves_voltage_support(self):
+        result = dispatch_volt_var(0.95, 90.0, 100.0)
+        self.assertAlmostEqual(result.capability.reactive_mvar, 50.0)
+        self.assertAlmostEqual(result.capability.active_mw, math.sqrt(7500.0))
+        self.assertTrue(result.capability.limited)
+
+    def test_active_priority_preserves_active_power(self):
+        result = dispatch_volt_var(
+            0.95,
+            90.0,
+            100.0,
+            priority=PowerPriority.ACTIVE,
+        )
+        self.assertAlmostEqual(result.capability.active_mw, 90.0)
+        self.assertAlmostEqual(result.capability.reactive_mvar, math.sqrt(1900.0))
+
+    def test_import_sign_is_preserved_during_reactive_priority(self):
+        result = dispatch_volt_var(1.05, -90.0, 100.0)
+        self.assertAlmostEqual(result.capability.reactive_mvar, -50.0)
+        self.assertAlmostEqual(result.capability.active_mw, -math.sqrt(7500.0))
+
+    def test_cli_reports_request_and_limited_dispatch(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--voltage-pu",
+                    "0.95",
+                    "--active-mw",
+                    "90",
+                    "--limit-mva",
+                    "100",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Volt-VAR request: 0.500 pu", output)
+        self.assertIn("Capability limited: true", output)
+        self.assertIn("Delivered active power: 86.603 MW", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a configurable four-breakpoint Volt-VAR curve with explicit Q sign convention
- validate ordered saturation/deadband breakpoints and reactive-power bounds
- pass reactive requests through the existing circular P-Q capability allocator
- support active- or reactive-priority conflict handling and direct CLI inspection
- document that default breakpoints are educational rather than grid-code settings

## Validation
- `python -m unittest discover -s tests -v` (15 passed)
- direct 0.95 pu / 90 MW / 100 MVA case delivered 86.603 MW and 50.000 MVAr
- Ruff lint and format checks passed for new Python files
- Python compilation passed
- changed-document Markdown lint passed
- all repository Markdown links passed
- `git diff --check` passed