### PR TITLE
Add frequency watt dispatch reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ and project teams.
 
 - [Executable active/reactive capability reference](models/README.md)
 - [Executable Volt-VAR dispatch reference](models/README.md#volt-var-dispatch-reference)
+- [Executable frequency-watt dispatch reference](models/README.md#frequency-watt-dispatch-reference)
 
 - [Grid-forming vs grid-following storage](concepts/grid-forming-vs-grid-following.md)
 - [Grid-code evidence prompt](concepts/grid-code-evidence-prompt.md)
@@ -98,6 +99,9 @@ python models/pq_capability.py `
   --active-mw 80 --reactive-mvar 80 --limit-mva 100 --priority active
 python models/volt_var.py `
   --voltage-pu 0.95 --active-mw 90 --limit-mva 100
+python models/frequency_watt.py `
+  --frequency-hz 49.725 --baseline-active-mw 20 `
+  --reactive-mvar 80 --limit-mva 100
 python -m unittest discover -s tests -v
 ```
 

--- a/models/README.md
+++ b/models/README.md
@@ -98,3 +98,42 @@ Use `--priority active` to study the competing policy that preserves active
 power and curtails the reactive request instead. Replace all breakpoints,
 reactive base, priority, and capability assumptions with project-controlled
 settings before engineering use.
+
+## Frequency-Watt Dispatch Reference
+
+[`frequency_watt.py`](frequency_watt.py) adds an illustrative frequency
+deadband, linear droop region, charge/discharge saturation, baseline schedule,
+and circular P-Q capability enforcement. Positive active power means discharge
+and injection into the grid; negative active power means charging. Below the
+lower deadband boundary, the controller increases injection. Above the upper
+deadband boundary, it reduces injection and can request charging.
+
+The defaults assume a 50 Hz system, a `+/-0.05 Hz` deadband, and full response
+at a `+/-0.50 Hz` deviation. These values are educational examples, not
+grid-code or plant settings.
+
+Run an under-frequency case with a 20 MW baseline export and an 80 MVAr request:
+
+```powershell
+python models/frequency_watt.py `
+  --frequency-hz 49.725 `
+  --baseline-active-mw 20 `
+  --reactive-mvar 80 `
+  --limit-mva 100
+```
+
+Expected key values with the default active-power priority:
+
+```text
+Droop adjustment: 50.000 MW
+Storage-bounded active request: 70.000 MW
+Capability limited: true
+Delivered active power: 70.000 MW
+Delivered reactive power: 71.414 MVAr
+```
+
+The model is static. It excludes frequency measurement filtering, control-loop
+dynamics, ramp-rate limits, state of charge, reserve availability, response
+duration, recovery logic, and interactions with plant-level dispatch. Replace
+the nominal frequency, breakpoints, power limits, baseline, and P-Q priority
+with project-controlled values before engineering use.

--- a/models/frequency_watt.py
+++ b/models/frequency_watt.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
+try:
+    from models.pq_capability import (
+        CapabilityResult,
+        PowerPriority,
+        allocate_power,
+    )
+except ModuleNotFoundError:
+    from pq_capability import CapabilityResult, PowerPriority, allocate_power
+
+
+@dataclass(frozen=True)
+class FrequencyWattCurve:
+    """Illustrative deadband and linear frequency-watt response."""
+
+    nominal_frequency_hz: float = 50.0
+    deadband_hz: float = 0.05
+    full_response_deviation_hz: float = 0.50
+    max_discharge_mw: float = 100.0
+    max_charge_mw: float = 100.0
+
+    def validate(self) -> None:
+        values = {
+            "nominal_frequency_hz": self.nominal_frequency_hz,
+            "deadband_hz": self.deadband_hz,
+            "full_response_deviation_hz": self.full_response_deviation_hz,
+            "max_discharge_mw": self.max_discharge_mw,
+            "max_charge_mw": self.max_charge_mw,
+        }
+        for name, value in values.items():
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+        if self.nominal_frequency_hz <= 0.0:
+            raise ValueError("nominal_frequency_hz must be positive")
+        if self.deadband_hz < 0.0:
+            raise ValueError("deadband_hz must be nonnegative")
+        if self.full_response_deviation_hz <= self.deadband_hz:
+            raise ValueError(
+                "full_response_deviation_hz must be greater than deadband_hz"
+            )
+        if self.max_discharge_mw <= 0.0 or self.max_charge_mw <= 0.0:
+            raise ValueError("charge and discharge limits must be positive")
+
+    def active_adjustment_mw(self, frequency_hz: float) -> float:
+        """Return positive response below nominal and negative response above."""
+
+        self.validate()
+        if not math.isfinite(frequency_hz) or frequency_hz <= 0.0:
+            raise ValueError("frequency_hz must be finite and positive")
+
+        deviation_hz = self.nominal_frequency_hz - frequency_hz
+        magnitude_hz = abs(deviation_hz)
+        if magnitude_hz <= self.deadband_hz:
+            return 0.0
+
+        response_fraction = min(
+            1.0,
+            (magnitude_hz - self.deadband_hz)
+            / (self.full_response_deviation_hz - self.deadband_hz),
+        )
+        if deviation_hz > 0.0:
+            return response_fraction * self.max_discharge_mw
+        return -response_fraction * self.max_charge_mw
+
+
+@dataclass(frozen=True)
+class FrequencyWattDispatch:
+    frequency_hz: float
+    baseline_active_mw: float
+    droop_adjustment_mw: float
+    unconstrained_active_mw: float
+    bounded_active_mw: float
+    storage_power_limited: bool
+    capability: CapabilityResult
+
+
+def dispatch_frequency_watt(
+    frequency_hz: float,
+    baseline_active_mw: float,
+    reactive_power_mvar: float,
+    apparent_power_limit_mva: float,
+    curve: FrequencyWattCurve = FrequencyWattCurve(),
+    priority: PowerPriority | str = PowerPriority.ACTIVE,
+) -> FrequencyWattDispatch:
+    """Evaluate frequency-watt response and enforce power and P-Q limits."""
+
+    if not math.isfinite(baseline_active_mw):
+        raise ValueError("baseline_active_mw must be finite")
+
+    adjustment_mw = curve.active_adjustment_mw(frequency_hz)
+    unconstrained_active_mw = baseline_active_mw + adjustment_mw
+    bounded_active_mw = max(
+        -curve.max_charge_mw,
+        min(curve.max_discharge_mw, unconstrained_active_mw),
+    )
+    storage_power_limited = not math.isclose(
+        unconstrained_active_mw,
+        bounded_active_mw,
+        rel_tol=0.0,
+        abs_tol=1e-12,
+    )
+    capability = allocate_power(
+        bounded_active_mw,
+        reactive_power_mvar,
+        apparent_power_limit_mva,
+        priority,
+    )
+    return FrequencyWattDispatch(
+        frequency_hz=frequency_hz,
+        baseline_active_mw=baseline_active_mw,
+        droop_adjustment_mw=adjustment_mw,
+        unconstrained_active_mw=unconstrained_active_mw,
+        bounded_active_mw=bounded_active_mw,
+        storage_power_limited=storage_power_limited,
+        capability=capability,
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate illustrative frequency-watt and P-Q dispatch."
+    )
+    parser.add_argument("--frequency-hz", type=float, required=True)
+    parser.add_argument("--baseline-active-mw", type=float, default=0.0)
+    parser.add_argument("--reactive-mvar", type=float, default=0.0)
+    parser.add_argument("--limit-mva", type=float, required=True)
+    parser.add_argument(
+        "--priority",
+        choices=[item.value for item in PowerPriority],
+        default=PowerPriority.ACTIVE.value,
+    )
+    parser.add_argument("--nominal-frequency-hz", type=float, default=50.0)
+    parser.add_argument("--deadband-hz", type=float, default=0.05)
+    parser.add_argument("--full-response-deviation-hz", type=float, default=0.50)
+    parser.add_argument("--max-discharge-mw", type=float, default=100.0)
+    parser.add_argument("--max-charge-mw", type=float, default=100.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    curve = FrequencyWattCurve(
+        nominal_frequency_hz=args.nominal_frequency_hz,
+        deadband_hz=args.deadband_hz,
+        full_response_deviation_hz=args.full_response_deviation_hz,
+        max_discharge_mw=args.max_discharge_mw,
+        max_charge_mw=args.max_charge_mw,
+    )
+    result = dispatch_frequency_watt(
+        frequency_hz=args.frequency_hz,
+        baseline_active_mw=args.baseline_active_mw,
+        reactive_power_mvar=args.reactive_mvar,
+        apparent_power_limit_mva=args.limit_mva,
+        curve=curve,
+        priority=args.priority,
+    )
+    capability = result.capability
+    print(f"Frequency: {result.frequency_hz:.3f} Hz")
+    print(f"Droop adjustment: {result.droop_adjustment_mw:.3f} MW")
+    print(f"Unconstrained active request: {result.unconstrained_active_mw:.3f} MW")
+    print(f"Storage-bounded active request: {result.bounded_active_mw:.3f} MW")
+    print(f"Storage power limited: {str(result.storage_power_limited).lower()}")
+    print(f"Capability priority: {capability.priority.value}")
+    print(f"Capability limited: {str(capability.limited).lower()}")
+    print(f"Delivered active power: {capability.active_mw:.3f} MW")
+    print(f"Delivered reactive power: {capability.reactive_mvar:.3f} MVAr")
+    print(f"Delivered apparent power: {capability.apparent_power_mva:.3f} MVA")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_frequency_watt.py
+++ b/tests/test_frequency_watt.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import math
+import unittest
+
+from models.frequency_watt import (
+    FrequencyWattCurve,
+    dispatch_frequency_watt,
+    main,
+)
+from models.pq_capability import PowerPriority
+
+
+class FrequencyWattTests(unittest.TestCase):
+    def test_deadband_includes_both_boundaries(self):
+        curve = FrequencyWattCurve()
+        self.assertEqual(curve.active_adjustment_mw(49.95), 0.0)
+        self.assertEqual(curve.active_adjustment_mw(50.00), 0.0)
+        self.assertEqual(curve.active_adjustment_mw(50.05), 0.0)
+
+    def test_under_frequency_response_interpolates_and_saturates(self):
+        curve = FrequencyWattCurve()
+        self.assertAlmostEqual(curve.active_adjustment_mw(49.725), 50.0)
+        self.assertEqual(curve.active_adjustment_mw(49.50), 100.0)
+        self.assertEqual(curve.active_adjustment_mw(48.00), 100.0)
+
+    def test_over_frequency_response_supports_asymmetric_charge_limit(self):
+        curve = FrequencyWattCurve(max_charge_mw=60.0)
+        self.assertAlmostEqual(curve.active_adjustment_mw(50.275), -30.0)
+        self.assertEqual(curve.active_adjustment_mw(50.50), -60.0)
+
+    def test_curve_rejects_invalid_configuration_and_frequency(self):
+        with self.assertRaisesRegex(ValueError, "greater than deadband"):
+            FrequencyWattCurve(
+                deadband_hz=0.5,
+                full_response_deviation_hz=0.5,
+            ).active_adjustment_mw(50.0)
+        with self.assertRaisesRegex(ValueError, "limits must be positive"):
+            FrequencyWattCurve(max_charge_mw=0.0).active_adjustment_mw(50.0)
+        with self.assertRaisesRegex(ValueError, "finite and positive"):
+            FrequencyWattCurve().active_adjustment_mw(math.nan)
+        with self.assertRaisesRegex(ValueError, "baseline_active_mw must be finite"):
+            dispatch_frequency_watt(50.0, math.inf, 0.0, 100.0)
+
+    def test_storage_power_limit_clips_baseline_plus_response(self):
+        result = dispatch_frequency_watt(49.725, 70.0, 0.0, 120.0)
+        self.assertAlmostEqual(result.droop_adjustment_mw, 50.0)
+        self.assertAlmostEqual(result.unconstrained_active_mw, 120.0)
+        self.assertAlmostEqual(result.bounded_active_mw, 100.0)
+        self.assertTrue(result.storage_power_limited)
+        self.assertFalse(result.capability.limited)
+
+    def test_active_priority_preserves_frequency_support(self):
+        result = dispatch_frequency_watt(49.725, 20.0, 80.0, 100.0)
+        self.assertAlmostEqual(result.bounded_active_mw, 70.0)
+        self.assertAlmostEqual(result.capability.active_mw, 70.0)
+        self.assertAlmostEqual(result.capability.reactive_mvar, math.sqrt(5100.0))
+        self.assertTrue(result.capability.limited)
+
+    def test_reactive_priority_can_curtail_frequency_support(self):
+        result = dispatch_frequency_watt(
+            49.725,
+            20.0,
+            80.0,
+            100.0,
+            priority=PowerPriority.REACTIVE,
+        )
+        self.assertAlmostEqual(result.capability.active_mw, 60.0)
+        self.assertAlmostEqual(result.capability.reactive_mvar, 80.0)
+
+    def test_operating_sweep_respects_storage_and_capability_limits(self):
+        for frequency_hz in (49.0, 49.725, 50.0, 50.275, 51.0):
+            for baseline_active_mw in (-120.0, 0.0, 120.0):
+                for reactive_power_mvar in (-120.0, 40.0, 120.0):
+                    for priority in PowerPriority:
+                        with self.subTest(
+                            frequency_hz=frequency_hz,
+                            baseline_active_mw=baseline_active_mw,
+                            reactive_power_mvar=reactive_power_mvar,
+                            priority=priority,
+                        ):
+                            result = dispatch_frequency_watt(
+                                frequency_hz,
+                                baseline_active_mw,
+                                reactive_power_mvar,
+                                100.0,
+                                priority=priority,
+                            )
+                            self.assertLessEqual(abs(result.bounded_active_mw), 100.0)
+                            self.assertLessEqual(
+                                result.capability.apparent_power_mva,
+                                100.0 + 1e-12,
+                            )
+
+    def test_cli_reports_response_and_capability_limit(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--frequency-hz",
+                    "49.725",
+                    "--baseline-active-mw",
+                    "20",
+                    "--reactive-mvar",
+                    "80",
+                    "--limit-mva",
+                    "100",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Droop adjustment: 50.000 MW", output)
+        self.assertIn("Capability limited: true", output)
+        self.assertIn("Delivered active power: 70.000 MW", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a configurable frequency-watt deadband, droop, and saturation reference
- enforce storage power and circular P-Q capability limits with explicit priority
- document sign conventions, runnable output, and engineering limitations

## Validation
- 24 unit tests passed, including an operating-surface invariant sweep
- reference CLI reproduced 70.000 MW / 71.414 MVAr at 100.000 MVA
- Ruff, compileall, Markdown lint, link checks, and whitespace checks passed