### PR TITLE
Add SOC-aware energy dispatch limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ and project teams.
 - [Executable active/reactive capability reference](models/README.md)
 - [Executable Volt-VAR dispatch reference](models/README.md#volt-var-dispatch-reference)
 - [Executable frequency-watt dispatch reference](models/README.md#frequency-watt-dispatch-reference)
+- [Executable SOC and response-duration limits](models/README.md#soc-and-response-duration-limits)
 
 - [Grid-forming vs grid-following storage](concepts/grid-forming-vs-grid-following.md)
 - [Grid-code evidence prompt](concepts/grid-code-evidence-prompt.md)
@@ -102,6 +103,10 @@ python models/volt_var.py `
 python models/frequency_watt.py `
   --frequency-hz 49.725 --baseline-active-mw 20 `
   --reactive-mvar 80 --limit-mva 100
+python models/energy_limits.py `
+  --active-mw 100 --duration-minutes 60 `
+  --energy-capacity-mwh 50 --initial-soc 0.50 `
+  --minimum-soc 0.20 --discharge-efficiency 0.90
 python -m unittest discover -s tests -v
 ```
 

--- a/concepts/storage-dispatch-basics.md
+++ b/concepts/storage-dispatch-basics.md
@@ -1,6 +1,12 @@
+<!-- markdownlint-disable MD013 MD060 -->
+
 # Storage Dispatch Basics
 
 Storage dispatch is the decision process for when a battery energy storage system charges, discharges, holds reserve, or stays idle.
+
+The [executable SOC and response-duration reference](../models/README.md#soc-and-response-duration-limits)
+shows how these concepts bound one constant-power interval before inverter
+active/reactive capability is applied.
 
 ## Core Idea
 

--- a/models/README.md
+++ b/models/README.md
@@ -49,8 +49,9 @@ python -m unittest discover -s tests -v
 ## Explicit Limitations
 
 - The capability boundary is a fixed circle rather than a manufacturer curve.
-- Dynamic current limits, voltage dependence, temperature derating, SOC, and
-  duration limits are excluded.
+- Dynamic current limits, voltage dependence, and temperature derating are
+  excluded. SOC and interval-duration limits can be composed through
+  `energy_limits.py`, but are not inherent to the P-Q allocator.
 - The allocator is static and does not model control-loop response.
 - Grid-code, protection, and plant-controller constraints remain project
   inputs.
@@ -133,7 +134,45 @@ Delivered reactive power: 71.414 MVAr
 ```
 
 The model is static. It excludes frequency measurement filtering, control-loop
-dynamics, ramp-rate limits, state of charge, reserve availability, response
-duration, recovery logic, and interactions with plant-level dispatch. Replace
-the nominal frequency, breakpoints, power limits, baseline, and P-Q priority
-with project-controlled values before engineering use.
+dynamics, ramp-rate limits, recovery logic, and interactions with plant-level
+dispatch. Optional energy arguments enforce SOC reserve, response duration, and
+charge/discharge efficiency before P-Q allocation. Replace every frequency,
+power, energy, efficiency, baseline, and priority assumption with
+project-controlled values before engineering use.
+
+## SOC And Response-Duration Limits
+
+[`energy_limits.py`](energy_limits.py) converts SOC headroom into the maximum
+constant AC charge or discharge power that can be sustained for one interval.
+Positive active power discharges the battery; negative active power charges it.
+Discharge efficiency increases the stored energy consumed per delivered MWh,
+while charge efficiency reduces the stored energy gained per imported MWh.
+
+Run a 60-minute discharge request that reaches a 20% minimum SOC boundary:
+
+```powershell
+python models/energy_limits.py `
+  --active-mw 100 --duration-minutes 60 `
+  --energy-capacity-mwh 50 --initial-soc 0.50 `
+  --minimum-soc 0.20 --discharge-efficiency 0.90
+```
+
+Expected key values:
+
+```text
+Delivered active power: 13.500 MW
+Energy limited: true
+Limiting boundary: minimum_soc
+Ending SOC: 0.2000
+```
+
+The same inputs can be added to `frequency_watt.py`; energy limiting is applied
+after the frequency response and instantaneous storage power bound, but before
+the P-Q capability allocator. This sequencing makes both energy curtailment and
+inverter curtailment visible. The returned `energy` result describes the
+energy-bounded request, while `delivered_energy` recomputes ending SOC from the
+active power that remains after P-Q allocation.
+
+This is a single-interval energy accounting reference. It does not model
+self-discharge, auxiliary load, nonlinear efficiency, degradation, thermal
+derating, uncertain capacity, multi-interval scheduling, or SOC recovery.

--- a/models/energy_limits.py
+++ b/models/energy_limits.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Sequence
+
+
+class EnergyBoundary(str, Enum):
+    MINIMUM_SOC = "minimum_soc"
+    MAXIMUM_SOC = "maximum_soc"
+
+
+@dataclass(frozen=True)
+class StorageEnergyState:
+    """Energy and SOC assumptions for one constant-power dispatch interval."""
+
+    energy_capacity_mwh: float
+    initial_soc: float
+    minimum_soc: float = 0.10
+    maximum_soc: float = 0.90
+    charge_efficiency: float = 0.95
+    discharge_efficiency: float = 0.95
+
+    def validate(self) -> None:
+        values = {
+            "energy_capacity_mwh": self.energy_capacity_mwh,
+            "initial_soc": self.initial_soc,
+            "minimum_soc": self.minimum_soc,
+            "maximum_soc": self.maximum_soc,
+            "charge_efficiency": self.charge_efficiency,
+            "discharge_efficiency": self.discharge_efficiency,
+        }
+        for name, value in values.items():
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+        if self.energy_capacity_mwh <= 0.0:
+            raise ValueError("energy_capacity_mwh must be positive")
+        if not (0.0 <= self.minimum_soc < self.maximum_soc <= 1.0):
+            raise ValueError(
+                "SOC limits must satisfy 0 <= minimum_soc < maximum_soc <= 1"
+            )
+        if not self.minimum_soc <= self.initial_soc <= self.maximum_soc:
+            raise ValueError("initial_soc must be within the configured SOC limits")
+        if not 0.0 < self.charge_efficiency <= 1.0:
+            raise ValueError("charge_efficiency must be within (0, 1]")
+        if not 0.0 < self.discharge_efficiency <= 1.0:
+            raise ValueError("discharge_efficiency must be within (0, 1]")
+
+
+@dataclass(frozen=True)
+class EnergyLimitedDispatch:
+    requested_active_mw: float
+    delivered_active_mw: float
+    duration_minutes: float
+    initial_soc: float
+    ending_soc: float
+    stored_energy_change_mwh: float
+    power_shortfall_mw: float
+    energy_limited: bool
+    limiting_boundary: EnergyBoundary | None
+
+
+def limit_active_power_by_energy(
+    requested_active_mw: float,
+    duration_minutes: float,
+    state: StorageEnergyState,
+) -> EnergyLimitedDispatch:
+    """Limit constant AC power so an interval ends inside configured SOC bounds."""
+
+    state.validate()
+    if not math.isfinite(requested_active_mw):
+        raise ValueError("requested_active_mw must be finite")
+    if not math.isfinite(duration_minutes) or duration_minutes <= 0.0:
+        raise ValueError("duration_minutes must be finite and positive")
+
+    duration_hours = duration_minutes / 60.0
+    if requested_active_mw > 0.0:
+        available_stored_energy_mwh = (
+            state.initial_soc - state.minimum_soc
+        ) * state.energy_capacity_mwh
+        maximum_discharge_mw = (
+            available_stored_energy_mwh * state.discharge_efficiency / duration_hours
+        )
+        delivered_active_mw = min(requested_active_mw, maximum_discharge_mw)
+        stored_energy_change_mwh = (
+            -delivered_active_mw * duration_hours / state.discharge_efficiency
+        )
+    elif requested_active_mw < 0.0:
+        available_storage_room_mwh = (
+            state.maximum_soc - state.initial_soc
+        ) * state.energy_capacity_mwh
+        maximum_charge_mw = available_storage_room_mwh / (
+            state.charge_efficiency * duration_hours
+        )
+        delivered_active_mw = max(requested_active_mw, -maximum_charge_mw)
+        stored_energy_change_mwh = (
+            -delivered_active_mw * duration_hours * state.charge_efficiency
+        )
+    else:
+        delivered_active_mw = 0.0
+        stored_energy_change_mwh = 0.0
+
+    ending_soc = state.initial_soc + (
+        stored_energy_change_mwh / state.energy_capacity_mwh
+    )
+    ending_soc = min(state.maximum_soc, max(state.minimum_soc, ending_soc))
+    energy_limited = not math.isclose(
+        delivered_active_mw,
+        requested_active_mw,
+        rel_tol=0.0,
+        abs_tol=1e-12,
+    )
+    limiting_boundary = None
+    if energy_limited:
+        limiting_boundary = (
+            EnergyBoundary.MINIMUM_SOC
+            if requested_active_mw > 0.0
+            else EnergyBoundary.MAXIMUM_SOC
+        )
+    return EnergyLimitedDispatch(
+        requested_active_mw=requested_active_mw,
+        delivered_active_mw=delivered_active_mw,
+        duration_minutes=duration_minutes,
+        initial_soc=state.initial_soc,
+        ending_soc=ending_soc,
+        stored_energy_change_mwh=stored_energy_change_mwh,
+        power_shortfall_mw=abs(requested_active_mw - delivered_active_mw),
+        energy_limited=energy_limited,
+        limiting_boundary=limiting_boundary,
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Apply SOC and interval-energy limits to active power."
+    )
+    parser.add_argument("--active-mw", type=float, required=True)
+    parser.add_argument("--duration-minutes", type=float, required=True)
+    parser.add_argument("--energy-capacity-mwh", type=float, required=True)
+    parser.add_argument("--initial-soc", type=float, required=True)
+    parser.add_argument("--minimum-soc", type=float, default=0.10)
+    parser.add_argument("--maximum-soc", type=float, default=0.90)
+    parser.add_argument("--charge-efficiency", type=float, default=0.95)
+    parser.add_argument("--discharge-efficiency", type=float, default=0.95)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    state = StorageEnergyState(
+        energy_capacity_mwh=args.energy_capacity_mwh,
+        initial_soc=args.initial_soc,
+        minimum_soc=args.minimum_soc,
+        maximum_soc=args.maximum_soc,
+        charge_efficiency=args.charge_efficiency,
+        discharge_efficiency=args.discharge_efficiency,
+    )
+    result = limit_active_power_by_energy(
+        args.active_mw,
+        args.duration_minutes,
+        state,
+    )
+    boundary = (
+        "none" if result.limiting_boundary is None else result.limiting_boundary.value
+    )
+    print(f"Requested active power: {result.requested_active_mw:.3f} MW")
+    print(f"Delivered active power: {result.delivered_active_mw:.3f} MW")
+    print(f"Response duration: {result.duration_minutes:.3f} minutes")
+    print(f"Energy limited: {str(result.energy_limited).lower()}")
+    print(f"Limiting boundary: {boundary}")
+    print(f"Initial SOC: {result.initial_soc:.4f}")
+    print(f"Ending SOC: {result.ending_soc:.4f}")
+    print(f"Stored energy change: {result.stored_energy_change_mwh:.3f} MWh")
+    print(f"Power shortfall: {result.power_shortfall_mw:.3f} MW")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/models/frequency_watt.py
+++ b/models/frequency_watt.py
@@ -6,6 +6,19 @@ from dataclasses import dataclass
 from typing import Sequence
 
 try:
+    from models.energy_limits import (
+        EnergyLimitedDispatch,
+        StorageEnergyState,
+        limit_active_power_by_energy,
+    )
+except ModuleNotFoundError:
+    from energy_limits import (
+        EnergyLimitedDispatch,
+        StorageEnergyState,
+        limit_active_power_by_energy,
+    )
+
+try:
     from models.pq_capability import (
         CapabilityResult,
         PowerPriority,
@@ -75,8 +88,11 @@ class FrequencyWattDispatch:
     baseline_active_mw: float
     droop_adjustment_mw: float
     unconstrained_active_mw: float
+    power_bounded_active_mw: float
     bounded_active_mw: float
     storage_power_limited: bool
+    energy: EnergyLimitedDispatch | None
+    delivered_energy: EnergyLimitedDispatch | None
     capability: CapabilityResult
 
 
@@ -87,37 +103,60 @@ def dispatch_frequency_watt(
     apparent_power_limit_mva: float,
     curve: FrequencyWattCurve = FrequencyWattCurve(),
     priority: PowerPriority | str = PowerPriority.ACTIVE,
+    energy_state: StorageEnergyState | None = None,
+    duration_minutes: float | None = None,
 ) -> FrequencyWattDispatch:
-    """Evaluate frequency-watt response and enforce power and P-Q limits."""
+    """Evaluate frequency response with optional interval energy enforcement."""
 
     if not math.isfinite(baseline_active_mw):
         raise ValueError("baseline_active_mw must be finite")
 
     adjustment_mw = curve.active_adjustment_mw(frequency_hz)
     unconstrained_active_mw = baseline_active_mw + adjustment_mw
-    bounded_active_mw = max(
+    power_bounded_active_mw = max(
         -curve.max_charge_mw,
         min(curve.max_discharge_mw, unconstrained_active_mw),
     )
     storage_power_limited = not math.isclose(
         unconstrained_active_mw,
-        bounded_active_mw,
+        power_bounded_active_mw,
         rel_tol=0.0,
         abs_tol=1e-12,
     )
+    if (energy_state is None) != (duration_minutes is None):
+        raise ValueError("energy_state and duration_minutes must be provided together")
+    energy = None
+    bounded_active_mw = power_bounded_active_mw
+    if energy_state is not None and duration_minutes is not None:
+        energy = limit_active_power_by_energy(
+            power_bounded_active_mw,
+            duration_minutes,
+            energy_state,
+        )
+        bounded_active_mw = energy.delivered_active_mw
     capability = allocate_power(
         bounded_active_mw,
         reactive_power_mvar,
         apparent_power_limit_mva,
         priority,
     )
+    delivered_energy = None
+    if energy_state is not None and duration_minutes is not None:
+        delivered_energy = limit_active_power_by_energy(
+            capability.active_mw,
+            duration_minutes,
+            energy_state,
+        )
     return FrequencyWattDispatch(
         frequency_hz=frequency_hz,
         baseline_active_mw=baseline_active_mw,
         droop_adjustment_mw=adjustment_mw,
         unconstrained_active_mw=unconstrained_active_mw,
+        power_bounded_active_mw=power_bounded_active_mw,
         bounded_active_mw=bounded_active_mw,
         storage_power_limited=storage_power_limited,
+        energy=energy,
+        delivered_energy=delivered_energy,
         capability=capability,
     )
 
@@ -140,6 +179,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--full-response-deviation-hz", type=float, default=0.50)
     parser.add_argument("--max-discharge-mw", type=float, default=100.0)
     parser.add_argument("--max-charge-mw", type=float, default=100.0)
+    parser.add_argument("--duration-minutes", type=float)
+    parser.add_argument("--energy-capacity-mwh", type=float)
+    parser.add_argument("--initial-soc", type=float)
+    parser.add_argument("--minimum-soc", type=float)
+    parser.add_argument("--maximum-soc", type=float)
+    parser.add_argument("--charge-efficiency", type=float)
+    parser.add_argument("--discharge-efficiency", type=float)
     return parser.parse_args(argv)
 
 
@@ -152,6 +198,41 @@ def main(argv: Sequence[str] | None = None) -> int:
         max_discharge_mw=args.max_discharge_mw,
         max_charge_mw=args.max_charge_mw,
     )
+    energy_inputs = (
+        args.duration_minutes,
+        args.energy_capacity_mwh,
+        args.initial_soc,
+        args.minimum_soc,
+        args.maximum_soc,
+        args.charge_efficiency,
+        args.discharge_efficiency,
+    )
+    required_energy_inputs = (
+        args.duration_minutes,
+        args.energy_capacity_mwh,
+        args.initial_soc,
+    )
+    if any(value is not None for value in energy_inputs) and not all(
+        value is not None for value in required_energy_inputs
+    ):
+        raise ValueError(
+            "duration_minutes, energy_capacity_mwh, and initial_soc "
+            "must be provided together"
+        )
+    energy_state = None
+    if args.energy_capacity_mwh is not None and args.initial_soc is not None:
+        energy_state = StorageEnergyState(
+            energy_capacity_mwh=args.energy_capacity_mwh,
+            initial_soc=args.initial_soc,
+            minimum_soc=0.10 if args.minimum_soc is None else args.minimum_soc,
+            maximum_soc=0.90 if args.maximum_soc is None else args.maximum_soc,
+            charge_efficiency=(
+                0.95 if args.charge_efficiency is None else args.charge_efficiency
+            ),
+            discharge_efficiency=(
+                0.95 if args.discharge_efficiency is None else args.discharge_efficiency
+            ),
+        )
     result = dispatch_frequency_watt(
         frequency_hz=args.frequency_hz,
         baseline_active_mw=args.baseline_active_mw,
@@ -159,13 +240,27 @@ def main(argv: Sequence[str] | None = None) -> int:
         apparent_power_limit_mva=args.limit_mva,
         curve=curve,
         priority=args.priority,
+        energy_state=energy_state,
+        duration_minutes=args.duration_minutes,
     )
     capability = result.capability
     print(f"Frequency: {result.frequency_hz:.3f} Hz")
     print(f"Droop adjustment: {result.droop_adjustment_mw:.3f} MW")
     print(f"Unconstrained active request: {result.unconstrained_active_mw:.3f} MW")
+    if result.energy is not None:
+        print(f"Power-bounded active request: {result.power_bounded_active_mw:.3f} MW")
     print(f"Storage-bounded active request: {result.bounded_active_mw:.3f} MW")
     print(f"Storage power limited: {str(result.storage_power_limited).lower()}")
+    if result.energy is not None:
+        boundary = (
+            "none"
+            if result.energy.limiting_boundary is None
+            else result.energy.limiting_boundary.value
+        )
+        print(f"Energy limited: {str(result.energy.energy_limited).lower()}")
+        print(f"Energy limiting boundary: {boundary}")
+        assert result.delivered_energy is not None
+        print(f"Ending SOC: {result.delivered_energy.ending_soc:.4f}")
     print(f"Capability priority: {capability.priority.value}")
     print(f"Capability limited: {str(capability.limited).lower()}")
     print(f"Delivered active power: {capability.active_mw:.3f} MW")

--- a/tests/test_energy_limits.py
+++ b/tests/test_energy_limits.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import math
+import unittest
+
+from models.energy_limits import (
+    EnergyBoundary,
+    StorageEnergyState,
+    limit_active_power_by_energy,
+    main,
+)
+
+
+class EnergyLimitsTests(unittest.TestCase):
+    def test_feasible_discharge_preserves_request_and_applies_losses(self):
+        state = StorageEnergyState(
+            energy_capacity_mwh=100.0,
+            initial_soc=0.50,
+            minimum_soc=0.20,
+            discharge_efficiency=0.90,
+        )
+        result = limit_active_power_by_energy(40.0, 30.0, state)
+        self.assertEqual(result.delivered_active_mw, 40.0)
+        self.assertAlmostEqual(result.stored_energy_change_mwh, -20.0 / 0.90)
+        self.assertAlmostEqual(result.ending_soc, 0.50 - 20.0 / 90.0)
+        self.assertFalse(result.energy_limited)
+        self.assertIsNone(result.limiting_boundary)
+
+    def test_discharge_is_limited_at_minimum_soc(self):
+        state = StorageEnergyState(
+            energy_capacity_mwh=50.0,
+            initial_soc=0.50,
+            minimum_soc=0.20,
+            discharge_efficiency=0.90,
+        )
+        result = limit_active_power_by_energy(100.0, 60.0, state)
+        self.assertAlmostEqual(result.delivered_active_mw, 13.5)
+        self.assertAlmostEqual(result.ending_soc, 0.20)
+        self.assertAlmostEqual(result.power_shortfall_mw, 86.5)
+        self.assertTrue(result.energy_limited)
+        self.assertIs(result.limiting_boundary, EnergyBoundary.MINIMUM_SOC)
+
+    def test_charge_is_limited_at_maximum_soc(self):
+        state = StorageEnergyState(
+            energy_capacity_mwh=50.0,
+            initial_soc=0.80,
+            maximum_soc=0.90,
+            charge_efficiency=0.80,
+        )
+        result = limit_active_power_by_energy(-100.0, 60.0, state)
+        self.assertAlmostEqual(result.delivered_active_mw, -6.25)
+        self.assertAlmostEqual(result.stored_energy_change_mwh, 5.0)
+        self.assertAlmostEqual(result.ending_soc, 0.90)
+        self.assertAlmostEqual(result.power_shortfall_mw, 93.75)
+        self.assertTrue(result.energy_limited)
+        self.assertIs(result.limiting_boundary, EnergyBoundary.MAXIMUM_SOC)
+
+    def test_zero_power_keeps_soc_unchanged(self):
+        state = StorageEnergyState(100.0, 0.50)
+        result = limit_active_power_by_energy(0.0, 15.0, state)
+        self.assertEqual(result.delivered_active_mw, 0.0)
+        self.assertEqual(result.stored_energy_change_mwh, 0.0)
+        self.assertEqual(result.ending_soc, 0.50)
+        self.assertFalse(result.energy_limited)
+
+    def test_boundary_states_block_only_the_outward_direction(self):
+        lower = StorageEnergyState(100.0, 0.20, minimum_soc=0.20)
+        upper = StorageEnergyState(100.0, 0.90, maximum_soc=0.90)
+        self.assertEqual(
+            limit_active_power_by_energy(10.0, 15.0, lower).delivered_active_mw,
+            0.0,
+        )
+        self.assertLess(
+            limit_active_power_by_energy(-10.0, 15.0, lower).delivered_active_mw,
+            0.0,
+        )
+        self.assertEqual(
+            limit_active_power_by_energy(-10.0, 15.0, upper).delivered_active_mw,
+            0.0,
+        )
+        self.assertGreater(
+            limit_active_power_by_energy(10.0, 15.0, upper).delivered_active_mw,
+            0.0,
+        )
+
+    def test_invalid_configuration_and_dispatch_inputs_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "energy_capacity_mwh"):
+            limit_active_power_by_energy(10.0, 15.0, StorageEnergyState(0.0, 0.5))
+        with self.assertRaisesRegex(ValueError, "SOC limits"):
+            limit_active_power_by_energy(
+                10.0,
+                15.0,
+                StorageEnergyState(100.0, 0.5, minimum_soc=0.9),
+            )
+        with self.assertRaisesRegex(ValueError, "initial_soc"):
+            limit_active_power_by_energy(10.0, 15.0, StorageEnergyState(100.0, 0.0))
+        with self.assertRaisesRegex(ValueError, "charge_efficiency"):
+            limit_active_power_by_energy(
+                10.0,
+                15.0,
+                StorageEnergyState(100.0, 0.5, charge_efficiency=1.1),
+            )
+        with self.assertRaisesRegex(ValueError, "requested_active_mw"):
+            limit_active_power_by_energy(math.nan, 15.0, StorageEnergyState(100.0, 0.5))
+        with self.assertRaisesRegex(ValueError, "duration_minutes"):
+            limit_active_power_by_energy(10.0, 0.0, StorageEnergyState(100.0, 0.5))
+
+    def test_operating_sweep_never_crosses_soc_boundaries(self):
+        for initial_soc in (0.20, 0.35, 0.75, 0.90):
+            for requested_active_mw in (-200.0, -20.0, 0.0, 20.0, 200.0):
+                for duration_minutes in (1.0, 15.0, 120.0):
+                    with self.subTest(
+                        initial_soc=initial_soc,
+                        requested_active_mw=requested_active_mw,
+                        duration_minutes=duration_minutes,
+                    ):
+                        state = StorageEnergyState(100.0, initial_soc)
+                        result = limit_active_power_by_energy(
+                            requested_active_mw,
+                            duration_minutes,
+                            state,
+                        )
+                        self.assertGreaterEqual(result.ending_soc, 0.10)
+                        self.assertLessEqual(result.ending_soc, 0.90)
+                        self.assertLessEqual(
+                            abs(result.delivered_active_mw),
+                            abs(requested_active_mw) + 1e-12,
+                        )
+
+    def test_cli_reports_limited_discharge_and_ending_soc(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--active-mw",
+                    "100",
+                    "--duration-minutes",
+                    "60",
+                    "--energy-capacity-mwh",
+                    "50",
+                    "--initial-soc",
+                    "0.5",
+                    "--minimum-soc",
+                    "0.2",
+                    "--discharge-efficiency",
+                    "0.9",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Delivered active power: 13.500 MW", output)
+        self.assertIn("Energy limited: true", output)
+        self.assertIn("Limiting boundary: minimum_soc", output)
+        self.assertIn("Ending SOC: 0.2000", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frequency_watt.py
+++ b/tests/test_frequency_watt.py
@@ -10,6 +10,7 @@ from models.frequency_watt import (
     dispatch_frequency_watt,
     main,
 )
+from models.energy_limits import EnergyBoundary, StorageEnergyState
 from models.pq_capability import PowerPriority
 
 
@@ -70,6 +71,81 @@ class FrequencyWattTests(unittest.TestCase):
         self.assertAlmostEqual(result.capability.active_mw, 60.0)
         self.assertAlmostEqual(result.capability.reactive_mvar, 80.0)
 
+    def test_energy_limit_preserves_soc_before_pq_allocation(self):
+        energy_state = StorageEnergyState(
+            energy_capacity_mwh=100.0,
+            initial_soc=0.25,
+            minimum_soc=0.20,
+            discharge_efficiency=0.90,
+        )
+        result = dispatch_frequency_watt(
+            49.725,
+            20.0,
+            80.0,
+            100.0,
+            energy_state=energy_state,
+            duration_minutes=15.0,
+        )
+        self.assertAlmostEqual(result.power_bounded_active_mw, 70.0)
+        self.assertAlmostEqual(result.bounded_active_mw, 18.0)
+        self.assertIsNotNone(result.energy)
+        assert result.energy is not None
+        self.assertTrue(result.energy.energy_limited)
+        self.assertIs(
+            result.energy.limiting_boundary,
+            EnergyBoundary.MINIMUM_SOC,
+        )
+        self.assertAlmostEqual(result.energy.ending_soc, 0.20)
+        self.assertIsNotNone(result.delivered_energy)
+        assert result.delivered_energy is not None
+        self.assertAlmostEqual(result.delivered_energy.ending_soc, 0.20)
+        self.assertAlmostEqual(result.capability.active_mw, 18.0)
+        self.assertAlmostEqual(result.capability.reactive_mvar, 80.0)
+        self.assertFalse(result.capability.limited)
+
+    def test_delivered_soc_accounts_for_pq_active_power_curtailment(self):
+        energy_state = StorageEnergyState(
+            energy_capacity_mwh=100.0,
+            initial_soc=0.90,
+            minimum_soc=0.10,
+            discharge_efficiency=1.0,
+        )
+        result = dispatch_frequency_watt(
+            49.725,
+            20.0,
+            80.0,
+            100.0,
+            priority=PowerPriority.REACTIVE,
+            energy_state=energy_state,
+            duration_minutes=60.0,
+        )
+        self.assertIsNotNone(result.energy)
+        self.assertIsNotNone(result.delivered_energy)
+        assert result.energy is not None
+        assert result.delivered_energy is not None
+        self.assertAlmostEqual(result.energy.ending_soc, 0.20)
+        self.assertAlmostEqual(result.capability.active_mw, 60.0)
+        self.assertAlmostEqual(result.delivered_energy.ending_soc, 0.30)
+
+    def test_energy_state_and_duration_must_be_provided_together(self):
+        state = StorageEnergyState(100.0, 0.5)
+        with self.assertRaisesRegex(ValueError, "must be provided together"):
+            dispatch_frequency_watt(
+                50.0,
+                0.0,
+                0.0,
+                100.0,
+                energy_state=state,
+            )
+        with self.assertRaisesRegex(ValueError, "must be provided together"):
+            dispatch_frequency_watt(
+                50.0,
+                0.0,
+                0.0,
+                100.0,
+                duration_minutes=15.0,
+            )
+
     def test_operating_sweep_respects_storage_and_capability_limits(self):
         for frequency_hz in (49.0, 49.725, 50.0, 50.275, 51.0):
             for baseline_active_mw in (-120.0, 0.0, 120.0):
@@ -114,6 +190,51 @@ class FrequencyWattTests(unittest.TestCase):
         self.assertIn("Droop adjustment: 50.000 MW", output)
         self.assertIn("Capability limited: true", output)
         self.assertIn("Delivered active power: 70.000 MW", output)
+
+    def test_cli_reports_soc_limited_frequency_response(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--frequency-hz",
+                    "49.725",
+                    "--baseline-active-mw",
+                    "20",
+                    "--reactive-mvar",
+                    "80",
+                    "--limit-mva",
+                    "100",
+                    "--duration-minutes",
+                    "15",
+                    "--energy-capacity-mwh",
+                    "100",
+                    "--initial-soc",
+                    "0.25",
+                    "--minimum-soc",
+                    "0.2",
+                    "--discharge-efficiency",
+                    "0.9",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Storage-bounded active request: 18.000 MW", output)
+        self.assertIn("Energy limited: true", output)
+        self.assertIn("Energy limiting boundary: minimum_soc", output)
+        self.assertIn("Ending SOC: 0.2000", output)
+
+    def test_cli_rejects_partial_energy_configuration(self):
+        with self.assertRaisesRegex(ValueError, "must be provided together"):
+            main(
+                [
+                    "--frequency-hz",
+                    "50",
+                    "--limit-mva",
+                    "100",
+                    "--minimum-soc",
+                    "0.2",
+                ]
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add an efficiency-aware interval energy limiter for charge and discharge commands
- enforce minimum and maximum SOC boundaries without changing command sign
- compose optional SOC and response-duration limits into frequency-watt dispatch before P-Q allocation
- report both the energy-bounded request and ending SOC from power actually delivered after P-Q curtailment
- document the sign convention, sequencing, assumptions, limitations, and runnable examples

## Why

The executable frequency-watt reference enforced instantaneous MW and MVA limits but explicitly excluded SOC, reserve bounds, efficiency, and response duration. That allowed a mathematically feasible power command to imply unavailable energy or cross an operating SOC boundary.

## Impact

Existing API and CLI behavior remains unchanged when energy inputs are omitted. When configured, the model converts SOC headroom into a sustainable constant AC command for the requested interval, exposes the limiting boundary and power shortfall, and recomputes ending SOC if inverter P-Q priority further curtails active power.

## Validation

- `python -m unittest discover -s tests -v` (37 tests passed)
- independent randomized property sweep (10,000 intervals passed SOC, sign, energy-balance, and boundary invariants)
- `uvx ruff check models tests` (pass)
- Ruff format check for all changed Python files (pass)
- Python 3.12 byte-compilation (pass)
- Markdown lint for all changed documentation (0 errors)
- documented standalone case: 100 MW request reduced to 13.5 MW for 60 minutes, ending at 0.2000 SOC
- integrated frequency-watt case: 70 MW request reduced to 18 MW for 15 minutes before P-Q allocation, ending at 0.2000 SOC
- `git diff --check` (pass)