### PR TITLE
Add active-power ramp-rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ and project teams.
 - [Executable active/reactive capability reference](models/README.md)
 - [Executable Volt-VAR dispatch reference](models/README.md#volt-var-dispatch-reference)
 - [Executable frequency-watt dispatch reference](models/README.md#frequency-watt-dispatch-reference)
+- [Executable active-power ramp limits](models/README.md#active-power-ramp-limits)
 - [Executable SOC and response-duration limits](models/README.md#soc-and-response-duration-limits)
 
 - [Grid-forming vs grid-following storage](concepts/grid-forming-vs-grid-following.md)
@@ -103,6 +104,9 @@ python models/volt_var.py `
 python models/frequency_watt.py `
   --frequency-hz 49.725 --baseline-active-mw 20 `
   --reactive-mvar 80 --limit-mva 100
+python models/ramp_limits.py `
+  --active-mw 80 --previous-active-mw 20 --interval-seconds 30 `
+  --ramp-up-mw-per-minute 40 --ramp-down-mw-per-minute 60
 python models/energy_limits.py `
   --active-mw 100 --duration-minutes 60 `
   --energy-capacity-mwh 50 --initial-soc 0.50 `

--- a/models/README.md
+++ b/models/README.md
@@ -134,11 +134,46 @@ Delivered reactive power: 71.414 MVAr
 ```
 
 The model is static. It excludes frequency measurement filtering, control-loop
-dynamics, ramp-rate limits, recovery logic, and interactions with plant-level
-dispatch. Optional energy arguments enforce SOC reserve, response duration, and
-charge/discharge efficiency before P-Q allocation. Replace every frequency,
-power, energy, efficiency, baseline, and priority assumption with
+dynamics, recovery logic, and interactions with plant-level dispatch. Optional
+ramp arguments enforce asymmetric signed active-power slew limits before SOC
+and P-Q allocation. Optional energy arguments then enforce SOC reserve,
+response duration, and charge/discharge efficiency. Replace every frequency,
+power, ramp, energy, efficiency, baseline, and priority assumption with
 project-controlled values before engineering use.
+
+## Active-Power Ramp Limits
+
+[`ramp_limits.py`](ramp_limits.py) converts separate ramp-up and ramp-down rates
+in MW/minute into the active-power interval reachable from the previous plant
+command. Increasing signed power is ramp-up, including movement from charging
+toward discharge; decreasing signed power is ramp-down. Crossing zero therefore
+uses one continuous signed slew limit rather than two disconnected magnitudes.
+
+Run a frequency event that requests 70 MW from a previous 20 MW operating point
+with only 30 seconds to respond:
+
+```powershell
+python models/frequency_watt.py `
+  --frequency-hz 49.725 --baseline-active-mw 20 `
+  --reactive-mvar 80 --limit-mva 100 `
+  --previous-active-mw 20 --ramp-interval-seconds 30 `
+  --ramp-up-mw-per-minute 40 --ramp-down-mw-per-minute 60
+```
+
+Expected ramp values:
+
+```text
+Power-bounded active request: 70.000 MW
+Ramp-bounded active request: 40.000 MW
+Ramp limited: true
+Ramp limiting direction: ramp_up
+```
+
+The integrated sequence is frequency-watt request, storage charge/discharge
+power bound, ramp bound, interval energy bound, and circular P-Q allocation.
+The returned `ramp`, `energy`, and `capability` records preserve each stage for
+review. The ramp interval is the time available to move from the previous
+command; it is distinct from the energy response duration.
 
 ## SOC And Response-Duration Limits
 

--- a/models/frequency_watt.py
+++ b/models/frequency_watt.py
@@ -27,6 +27,19 @@ try:
 except ModuleNotFoundError:
     from pq_capability import CapabilityResult, PowerPriority, allocate_power
 
+try:
+    from models.ramp_limits import (
+        RampLimitedDispatch,
+        RampRateLimits,
+        limit_active_power_by_ramp,
+    )
+except ModuleNotFoundError:
+    from ramp_limits import (
+        RampLimitedDispatch,
+        RampRateLimits,
+        limit_active_power_by_ramp,
+    )
+
 
 @dataclass(frozen=True)
 class FrequencyWattCurve:
@@ -89,8 +102,10 @@ class FrequencyWattDispatch:
     droop_adjustment_mw: float
     unconstrained_active_mw: float
     power_bounded_active_mw: float
+    ramp_bounded_active_mw: float
     bounded_active_mw: float
     storage_power_limited: bool
+    ramp: RampLimitedDispatch | None
     energy: EnergyLimitedDispatch | None
     delivered_energy: EnergyLimitedDispatch | None
     capability: CapabilityResult
@@ -105,8 +120,11 @@ def dispatch_frequency_watt(
     priority: PowerPriority | str = PowerPriority.ACTIVE,
     energy_state: StorageEnergyState | None = None,
     duration_minutes: float | None = None,
+    ramp_limits: RampRateLimits | None = None,
+    previous_active_mw: float | None = None,
+    ramp_interval_seconds: float | None = None,
 ) -> FrequencyWattDispatch:
-    """Evaluate frequency response with optional interval energy enforcement."""
+    """Evaluate frequency response with optional ramp and energy enforcement."""
 
     if not math.isfinite(baseline_active_mw):
         raise ValueError("baseline_active_mw must be finite")
@@ -125,11 +143,37 @@ def dispatch_frequency_watt(
     )
     if (energy_state is None) != (duration_minutes is None):
         raise ValueError("energy_state and duration_minutes must be provided together")
+    ramp_inputs = (ramp_limits, previous_active_mw, ramp_interval_seconds)
+    if any(value is not None for value in ramp_inputs) and not all(
+        value is not None for value in ramp_inputs
+    ):
+        raise ValueError(
+            "ramp_limits, previous_active_mw, and ramp_interval_seconds "
+            "must be provided together"
+        )
+    ramp = None
+    ramp_bounded_active_mw = power_bounded_active_mw
+    if (
+        ramp_limits is not None
+        and previous_active_mw is not None
+        and ramp_interval_seconds is not None
+    ):
+        if not (-curve.max_charge_mw <= previous_active_mw <= curve.max_discharge_mw):
+            raise ValueError(
+                "previous_active_mw must be within configured storage power limits"
+            )
+        ramp = limit_active_power_by_ramp(
+            power_bounded_active_mw,
+            previous_active_mw,
+            ramp_interval_seconds,
+            ramp_limits,
+        )
+        ramp_bounded_active_mw = ramp.delivered_active_mw
     energy = None
-    bounded_active_mw = power_bounded_active_mw
+    bounded_active_mw = ramp_bounded_active_mw
     if energy_state is not None and duration_minutes is not None:
         energy = limit_active_power_by_energy(
-            power_bounded_active_mw,
+            ramp_bounded_active_mw,
             duration_minutes,
             energy_state,
         )
@@ -153,8 +197,10 @@ def dispatch_frequency_watt(
         droop_adjustment_mw=adjustment_mw,
         unconstrained_active_mw=unconstrained_active_mw,
         power_bounded_active_mw=power_bounded_active_mw,
+        ramp_bounded_active_mw=ramp_bounded_active_mw,
         bounded_active_mw=bounded_active_mw,
         storage_power_limited=storage_power_limited,
+        ramp=ramp,
         energy=energy,
         delivered_energy=delivered_energy,
         capability=capability,
@@ -179,6 +225,10 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--full-response-deviation-hz", type=float, default=0.50)
     parser.add_argument("--max-discharge-mw", type=float, default=100.0)
     parser.add_argument("--max-charge-mw", type=float, default=100.0)
+    parser.add_argument("--previous-active-mw", type=float)
+    parser.add_argument("--ramp-interval-seconds", type=float)
+    parser.add_argument("--ramp-up-mw-per-minute", type=float)
+    parser.add_argument("--ramp-down-mw-per-minute", type=float)
     parser.add_argument("--duration-minutes", type=float)
     parser.add_argument("--energy-capacity-mwh", type=float)
     parser.add_argument("--initial-soc", type=float)
@@ -233,6 +283,29 @@ def main(argv: Sequence[str] | None = None) -> int:
                 0.95 if args.discharge_efficiency is None else args.discharge_efficiency
             ),
         )
+    ramp_inputs = (
+        args.previous_active_mw,
+        args.ramp_interval_seconds,
+        args.ramp_up_mw_per_minute,
+        args.ramp_down_mw_per_minute,
+    )
+    if any(value is not None for value in ramp_inputs) and not all(
+        value is not None for value in ramp_inputs
+    ):
+        raise ValueError(
+            "previous_active_mw, ramp_interval_seconds, "
+            "ramp_up_mw_per_minute, and ramp_down_mw_per_minute "
+            "must be provided together"
+        )
+    ramp_limits = None
+    if (
+        args.ramp_up_mw_per_minute is not None
+        and args.ramp_down_mw_per_minute is not None
+    ):
+        ramp_limits = RampRateLimits(
+            args.ramp_up_mw_per_minute,
+            args.ramp_down_mw_per_minute,
+        )
     result = dispatch_frequency_watt(
         frequency_hz=args.frequency_hz,
         baseline_active_mw=args.baseline_active_mw,
@@ -242,13 +315,26 @@ def main(argv: Sequence[str] | None = None) -> int:
         priority=args.priority,
         energy_state=energy_state,
         duration_minutes=args.duration_minutes,
+        ramp_limits=ramp_limits,
+        previous_active_mw=args.previous_active_mw,
+        ramp_interval_seconds=args.ramp_interval_seconds,
     )
     capability = result.capability
     print(f"Frequency: {result.frequency_hz:.3f} Hz")
     print(f"Droop adjustment: {result.droop_adjustment_mw:.3f} MW")
     print(f"Unconstrained active request: {result.unconstrained_active_mw:.3f} MW")
-    if result.energy is not None:
+    if result.ramp is not None or result.energy is not None:
         print(f"Power-bounded active request: {result.power_bounded_active_mw:.3f} MW")
+    if result.ramp is not None:
+        direction = (
+            "none"
+            if result.ramp.limiting_direction is None
+            else result.ramp.limiting_direction.value
+        )
+        print(f"Previous active power: {result.ramp.previous_active_mw:.3f} MW")
+        print(f"Ramp-bounded active request: {result.ramp_bounded_active_mw:.3f} MW")
+        print(f"Ramp limited: {str(result.ramp.ramp_limited).lower()}")
+        print(f"Ramp limiting direction: {direction}")
     print(f"Storage-bounded active request: {result.bounded_active_mw:.3f} MW")
     print(f"Storage power limited: {str(result.storage_power_limited).lower()}")
     if result.energy is not None:

--- a/models/ramp_limits.py
+++ b/models/ramp_limits.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Sequence
+
+
+class RampDirection(str, Enum):
+    UP = "ramp_up"
+    DOWN = "ramp_down"
+
+
+@dataclass(frozen=True)
+class RampRateLimits:
+    """Asymmetric signed active-power slew limits."""
+
+    ramp_up_mw_per_minute: float
+    ramp_down_mw_per_minute: float
+
+    def validate(self) -> None:
+        values = {
+            "ramp_up_mw_per_minute": self.ramp_up_mw_per_minute,
+            "ramp_down_mw_per_minute": self.ramp_down_mw_per_minute,
+        }
+        for name, value in values.items():
+            if not math.isfinite(value) or value <= 0.0:
+                raise ValueError(f"{name} must be finite and positive")
+
+
+@dataclass(frozen=True)
+class RampLimitedDispatch:
+    previous_active_mw: float
+    requested_active_mw: float
+    delivered_active_mw: float
+    interval_seconds: float
+    minimum_active_mw: float
+    maximum_active_mw: float
+    power_change_mw: float
+    power_shortfall_mw: float
+    ramp_limited: bool
+    limiting_direction: RampDirection | None
+
+
+def limit_active_power_by_ramp(
+    requested_active_mw: float,
+    previous_active_mw: float,
+    interval_seconds: float,
+    limits: RampRateLimits,
+) -> RampLimitedDispatch:
+    """Limit a signed active-power request to the reachable ramp interval."""
+
+    limits.validate()
+    values = {
+        "requested_active_mw": requested_active_mw,
+        "previous_active_mw": previous_active_mw,
+        "interval_seconds": interval_seconds,
+    }
+    for name, value in values.items():
+        if not math.isfinite(value):
+            raise ValueError(f"{name} must be finite")
+    if interval_seconds <= 0.0:
+        raise ValueError("interval_seconds must be positive")
+
+    interval_minutes = interval_seconds / 60.0
+    minimum_active_mw = (
+        previous_active_mw - limits.ramp_down_mw_per_minute * interval_minutes
+    )
+    maximum_active_mw = (
+        previous_active_mw + limits.ramp_up_mw_per_minute * interval_minutes
+    )
+    delivered_active_mw = max(
+        minimum_active_mw,
+        min(maximum_active_mw, requested_active_mw),
+    )
+    limiting_direction = None
+    if requested_active_mw > maximum_active_mw:
+        limiting_direction = RampDirection.UP
+    elif requested_active_mw < minimum_active_mw:
+        limiting_direction = RampDirection.DOWN
+    ramp_limited = limiting_direction is not None
+
+    return RampLimitedDispatch(
+        previous_active_mw=previous_active_mw,
+        requested_active_mw=requested_active_mw,
+        delivered_active_mw=delivered_active_mw,
+        interval_seconds=interval_seconds,
+        minimum_active_mw=minimum_active_mw,
+        maximum_active_mw=maximum_active_mw,
+        power_change_mw=delivered_active_mw - previous_active_mw,
+        power_shortfall_mw=abs(requested_active_mw - delivered_active_mw),
+        ramp_limited=ramp_limited,
+        limiting_direction=limiting_direction,
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Apply asymmetric ramp limits to signed active power."
+    )
+    parser.add_argument("--active-mw", type=float, required=True)
+    parser.add_argument("--previous-active-mw", type=float, required=True)
+    parser.add_argument("--interval-seconds", type=float, required=True)
+    parser.add_argument("--ramp-up-mw-per-minute", type=float, required=True)
+    parser.add_argument("--ramp-down-mw-per-minute", type=float, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    result = limit_active_power_by_ramp(
+        args.active_mw,
+        args.previous_active_mw,
+        args.interval_seconds,
+        RampRateLimits(
+            args.ramp_up_mw_per_minute,
+            args.ramp_down_mw_per_minute,
+        ),
+    )
+    direction = (
+        "none" if result.limiting_direction is None else result.limiting_direction.value
+    )
+    print(f"Previous active power: {result.previous_active_mw:.3f} MW")
+    print(f"Requested active power: {result.requested_active_mw:.3f} MW")
+    print(f"Delivered active power: {result.delivered_active_mw:.3f} MW")
+    print(f"Ramp interval: {result.interval_seconds:.3f} seconds")
+    print(f"Reachable minimum: {result.minimum_active_mw:.3f} MW")
+    print(f"Reachable maximum: {result.maximum_active_mw:.3f} MW")
+    print(f"Ramp limited: {str(result.ramp_limited).lower()}")
+    print(f"Limiting direction: {direction}")
+    print(f"Power shortfall: {result.power_shortfall_mw:.3f} MW")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_frequency_watt.py
+++ b/tests/test_frequency_watt.py
@@ -12,6 +12,7 @@ from models.frequency_watt import (
 )
 from models.energy_limits import EnergyBoundary, StorageEnergyState
 from models.pq_capability import PowerPriority
+from models.ramp_limits import RampDirection, RampRateLimits
 
 
 class FrequencyWattTests(unittest.TestCase):
@@ -102,6 +103,57 @@ class FrequencyWattTests(unittest.TestCase):
         self.assertAlmostEqual(result.capability.active_mw, 18.0)
         self.assertAlmostEqual(result.capability.reactive_mvar, 80.0)
         self.assertFalse(result.capability.limited)
+
+    def test_ramp_limit_applies_before_energy_and_capability(self):
+        energy_state = StorageEnergyState(
+            energy_capacity_mwh=100.0,
+            initial_soc=0.50,
+            minimum_soc=0.10,
+            discharge_efficiency=1.0,
+        )
+        result = dispatch_frequency_watt(
+            49.725,
+            20.0,
+            95.0,
+            100.0,
+            priority=PowerPriority.REACTIVE,
+            energy_state=energy_state,
+            duration_minutes=15.0,
+            ramp_limits=RampRateLimits(40.0, 60.0),
+            previous_active_mw=20.0,
+            ramp_interval_seconds=30.0,
+        )
+        self.assertAlmostEqual(result.power_bounded_active_mw, 70.0)
+        self.assertAlmostEqual(result.ramp_bounded_active_mw, 40.0)
+        self.assertIsNotNone(result.ramp)
+        assert result.ramp is not None
+        self.assertTrue(result.ramp.ramp_limited)
+        self.assertIs(result.ramp.limiting_direction, RampDirection.UP)
+        self.assertIsNotNone(result.energy)
+        assert result.energy is not None
+        self.assertAlmostEqual(result.energy.requested_active_mw, 40.0)
+        self.assertAlmostEqual(result.capability.active_mw, 31.22498999199199)
+        self.assertAlmostEqual(result.capability.reactive_mvar, 95.0)
+
+    def test_ramp_configuration_and_previous_power_are_validated(self):
+        with self.assertRaisesRegex(ValueError, "must be provided together"):
+            dispatch_frequency_watt(
+                50.0,
+                0.0,
+                0.0,
+                100.0,
+                ramp_limits=RampRateLimits(10.0, 10.0),
+            )
+        with self.assertRaisesRegex(ValueError, "storage power limits"):
+            dispatch_frequency_watt(
+                50.0,
+                0.0,
+                0.0,
+                100.0,
+                ramp_limits=RampRateLimits(10.0, 10.0),
+                previous_active_mw=101.0,
+                ramp_interval_seconds=30.0,
+            )
 
     def test_delivered_soc_accounts_for_pq_active_power_curtailment(self):
         energy_state = StorageEnergyState(
@@ -222,6 +274,35 @@ class FrequencyWattTests(unittest.TestCase):
         self.assertIn("Energy limited: true", output)
         self.assertIn("Energy limiting boundary: minimum_soc", output)
         self.assertIn("Ending SOC: 0.2000", output)
+
+    def test_cli_reports_ramp_limited_frequency_response(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--frequency-hz",
+                    "49.725",
+                    "--baseline-active-mw",
+                    "20",
+                    "--reactive-mvar",
+                    "80",
+                    "--limit-mva",
+                    "100",
+                    "--previous-active-mw",
+                    "20",
+                    "--ramp-interval-seconds",
+                    "30",
+                    "--ramp-up-mw-per-minute",
+                    "40",
+                    "--ramp-down-mw-per-minute",
+                    "60",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Ramp-bounded active request: 40.000 MW", output)
+        self.assertIn("Ramp limited: true", output)
+        self.assertIn("Ramp limiting direction: ramp_up", output)
 
     def test_cli_rejects_partial_energy_configuration(self):
         with self.assertRaisesRegex(ValueError, "must be provided together"):

--- a/tests/test_ramp_limits.py
+++ b/tests/test_ramp_limits.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import math
+import unittest
+
+from models.ramp_limits import (
+    RampDirection,
+    RampRateLimits,
+    limit_active_power_by_ramp,
+    main,
+)
+
+
+class RampLimitsTests(unittest.TestCase):
+    def test_ramp_up_limits_increasing_discharge(self):
+        result = limit_active_power_by_ramp(
+            80.0,
+            20.0,
+            30.0,
+            RampRateLimits(40.0, 60.0),
+        )
+        self.assertEqual(result.delivered_active_mw, 40.0)
+        self.assertEqual(result.power_change_mw, 20.0)
+        self.assertEqual(result.power_shortfall_mw, 40.0)
+        self.assertTrue(result.ramp_limited)
+        self.assertIs(result.limiting_direction, RampDirection.UP)
+
+    def test_ramp_down_uses_asymmetric_rate(self):
+        result = limit_active_power_by_ramp(
+            -50.0,
+            20.0,
+            30.0,
+            RampRateLimits(40.0, 60.0),
+        )
+        self.assertEqual(result.delivered_active_mw, -10.0)
+        self.assertEqual(result.minimum_active_mw, -10.0)
+        self.assertIs(result.limiting_direction, RampDirection.DOWN)
+
+    def test_feasible_request_passes_through(self):
+        result = limit_active_power_by_ramp(
+            25.0,
+            20.0,
+            30.0,
+            RampRateLimits(40.0, 60.0),
+        )
+        self.assertEqual(result.delivered_active_mw, 25.0)
+        self.assertFalse(result.ramp_limited)
+        self.assertIsNone(result.limiting_direction)
+
+    def test_tiny_interval_overshoot_reports_ramp_limit(self):
+        result = limit_active_power_by_ramp(
+            20.0 + 1e-13,
+            10.0,
+            30.0,
+            RampRateLimits(20.0, 30.0),
+        )
+        self.assertEqual(result.delivered_active_mw, 20.0)
+        self.assertTrue(result.ramp_limited)
+        self.assertIs(result.limiting_direction, RampDirection.UP)
+
+    def test_crossing_zero_preserves_signed_slew_limit(self):
+        result = limit_active_power_by_ramp(
+            30.0,
+            -20.0,
+            120.0,
+            RampRateLimits(10.0, 30.0),
+        )
+        self.assertEqual(result.delivered_active_mw, 0.0)
+        self.assertEqual(result.power_change_mw, 20.0)
+        self.assertIs(result.limiting_direction, RampDirection.UP)
+
+    def test_invalid_rates_and_inputs_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "ramp_up_mw_per_minute"):
+            limit_active_power_by_ramp(
+                10.0,
+                0.0,
+                30.0,
+                RampRateLimits(0.0, 10.0),
+            )
+        with self.assertRaisesRegex(ValueError, "interval_seconds"):
+            limit_active_power_by_ramp(
+                10.0,
+                0.0,
+                0.0,
+                RampRateLimits(10.0, 10.0),
+            )
+        with self.assertRaisesRegex(ValueError, "requested_active_mw"):
+            limit_active_power_by_ramp(
+                math.nan,
+                0.0,
+                30.0,
+                RampRateLimits(10.0, 10.0),
+            )
+
+    def test_operating_sweep_stays_inside_reachable_interval(self):
+        limits = RampRateLimits(17.0, 31.0)
+        for previous_active_mw in (-100.0, -10.0, 0.0, 30.0, 100.0):
+            for requested_active_mw in (-200.0, -20.0, 0.0, 40.0, 200.0):
+                for interval_seconds in (0.1, 15.0, 300.0):
+                    with self.subTest(
+                        previous_active_mw=previous_active_mw,
+                        requested_active_mw=requested_active_mw,
+                        interval_seconds=interval_seconds,
+                    ):
+                        result = limit_active_power_by_ramp(
+                            requested_active_mw,
+                            previous_active_mw,
+                            interval_seconds,
+                            limits,
+                        )
+                        self.assertGreaterEqual(
+                            result.delivered_active_mw,
+                            result.minimum_active_mw - 1e-12,
+                        )
+                        self.assertLessEqual(
+                            result.delivered_active_mw,
+                            result.maximum_active_mw + 1e-12,
+                        )
+                        self.assertLessEqual(
+                            abs(result.delivered_active_mw - requested_active_mw),
+                            abs(previous_active_mw - requested_active_mw) + 1e-12,
+                        )
+
+    def test_cli_reports_limited_ramp_up(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--active-mw",
+                    "80",
+                    "--previous-active-mw",
+                    "20",
+                    "--interval-seconds",
+                    "30",
+                    "--ramp-up-mw-per-minute",
+                    "40",
+                    "--ramp-down-mw-per-minute",
+                    "60",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Delivered active power: 40.000 MW", output)
+        self.assertIn("Ramp limited: true", output)
+        self.assertIn("Limiting direction: ramp_up", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reusable asymmetric signed active-power ramp limiter
- integrate ramp enforcement between storage power and interval-energy limits
- document standalone and frequency-watt CLI usage, including zero crossing

## Validation
- `python -m unittest discover -s tests -q` (48 tests)
- `ruff check` on all changed Python files
- `ruff format --check` on all changed Python files
- `python -m compileall -q models tests`
- 10,000-case randomized invariant sweep
- end-to-end ramp-limited frequency-watt CLI scenario