### PR TITLE
Add frequency measurement filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ and project teams.
 - [Executable active/reactive capability reference](models/README.md)
 - [Executable Volt-VAR dispatch reference](models/README.md#volt-var-dispatch-reference)
 - [Executable frequency-watt dispatch reference](models/README.md#frequency-watt-dispatch-reference)
+- [Executable frequency measurement filter](models/README.md#frequency-measurement-filter)
 - [Executable active-power ramp limits](models/README.md#active-power-ramp-limits)
 - [Executable SOC and response-duration limits](models/README.md#soc-and-response-duration-limits)
 
@@ -104,6 +105,9 @@ python models/volt_var.py `
 python models/frequency_watt.py `
   --frequency-hz 49.725 --baseline-active-mw 20 `
   --reactive-mvar 80 --limit-mva 100
+python models/measurement_filter.py `
+  --input-value 49.5 --previous-output-value 50 `
+  --interval-seconds 0.1 --time-constant-seconds 1
 python models/ramp_limits.py `
   --active-mw 80 --previous-active-mw 20 --interval-seconds 30 `
   --ramp-up-mw-per-minute 40 --ramp-down-mw-per-minute 60

--- a/models/README.md
+++ b/models/README.md
@@ -133,13 +133,53 @@ Delivered active power: 70.000 MW
 Delivered reactive power: 71.414 MVAr
 ```
 
-The model is static. It excludes frequency measurement filtering, control-loop
-dynamics, recovery logic, and interactions with plant-level dispatch. Optional
-ramp arguments enforce asymmetric signed active-power slew limits before SOC
-and P-Q allocation. Optional energy arguments then enforce SOC reserve,
-response duration, and charge/discharge efficiency. Replace every frequency,
+The model is static. It excludes sensor errors, higher-order measurement
+dynamics, control-loop dynamics, recovery logic, and interactions with
+plant-level dispatch. Optional filter arguments apply a first-order frequency
+measurement filter before deadband and droop evaluation. Optional ramp
+arguments enforce asymmetric signed active-power slew limits before SOC and P-Q
+allocation. Optional energy arguments then enforce SOC reserve, response
+duration, and charge/discharge efficiency. Replace every frequency, filter,
 power, ramp, energy, efficiency, baseline, and priority assumption with
 project-controlled values before engineering use.
+
+## Frequency Measurement Filter
+
+[`measurement_filter.py`](measurement_filter.py) applies the exact
+zero-order-hold solution of a first-order low-pass filter over one interval:
+
+```text
+y_next = input + (y_previous - input) exp(-interval / time_constant)
+```
+
+This makes the raw frequency measurement and the filtered control frequency
+separate, reviewable values. For example, a sudden raw measurement of 49.5 Hz
+does not immediately leave the default deadband when the previous filtered
+value is 50 Hz, the sample interval is 0.1 seconds, and the filter time constant
+is 1 second:
+
+```powershell
+python models/frequency_watt.py `
+  --frequency-hz 49.5 --baseline-active-mw 0 `
+  --reactive-mvar 0 --limit-mva 100 `
+  --previous-filtered-frequency-hz 50 `
+  --measurement-interval-seconds 0.1 `
+  --frequency-filter-time-constant-seconds 1
+```
+
+Expected filter and droop values:
+
+```text
+Frequency: 49.500 Hz
+Control frequency: 49.952 Hz
+Frequency-filter decay factor: 0.904837
+Droop adjustment: 0.000 MW
+```
+
+The previous filtered value must be carried from the prior control interval.
+The model assumes one constant input during each interval; it does not represent
+sampling jitter, sensor bias, rate-of-change-of-frequency logic, or a
+higher-order plant controller.
 
 ## Active-Power Ramp Limits
 
@@ -169,8 +209,9 @@ Ramp limited: true
 Ramp limiting direction: ramp_up
 ```
 
-The integrated sequence is frequency-watt request, storage charge/discharge
-power bound, ramp bound, interval energy bound, and circular P-Q allocation.
+The integrated sequence is raw measurement, optional frequency filter,
+frequency-watt request, storage charge/discharge power bound, ramp bound,
+interval energy bound, and circular P-Q allocation.
 The returned `ramp`, `energy`, and `capability` records preserve each stage for
 review. The ramp interval is the time available to move from the previous
 command; it is distinct from the energy response duration.

--- a/models/frequency_watt.py
+++ b/models/frequency_watt.py
@@ -19,6 +19,19 @@ except ModuleNotFoundError:
     )
 
 try:
+    from models.measurement_filter import (
+        FirstOrderFilterConfig,
+        FirstOrderFilterStep,
+        filter_first_order_step,
+    )
+except ModuleNotFoundError:
+    from measurement_filter import (
+        FirstOrderFilterConfig,
+        FirstOrderFilterStep,
+        filter_first_order_step,
+    )
+
+try:
     from models.pq_capability import (
         CapabilityResult,
         PowerPriority,
@@ -98,6 +111,7 @@ class FrequencyWattCurve:
 @dataclass(frozen=True)
 class FrequencyWattDispatch:
     frequency_hz: float
+    control_frequency_hz: float
     baseline_active_mw: float
     droop_adjustment_mw: float
     unconstrained_active_mw: float
@@ -105,6 +119,7 @@ class FrequencyWattDispatch:
     ramp_bounded_active_mw: float
     bounded_active_mw: float
     storage_power_limited: bool
+    frequency_filter: FirstOrderFilterStep | None
     ramp: RampLimitedDispatch | None
     energy: EnergyLimitedDispatch | None
     delivered_energy: EnergyLimitedDispatch | None
@@ -123,13 +138,47 @@ def dispatch_frequency_watt(
     ramp_limits: RampRateLimits | None = None,
     previous_active_mw: float | None = None,
     ramp_interval_seconds: float | None = None,
+    frequency_filter_config: FirstOrderFilterConfig | None = None,
+    previous_filtered_frequency_hz: float | None = None,
+    measurement_interval_seconds: float | None = None,
 ) -> FrequencyWattDispatch:
-    """Evaluate frequency response with optional ramp and energy enforcement."""
+    """Evaluate frequency response with optional measurement and plant limits."""
 
     if not math.isfinite(baseline_active_mw):
         raise ValueError("baseline_active_mw must be finite")
+    if not math.isfinite(frequency_hz) or frequency_hz <= 0.0:
+        raise ValueError("frequency_hz must be finite and positive")
 
-    adjustment_mw = curve.active_adjustment_mw(frequency_hz)
+    filter_inputs = (
+        frequency_filter_config,
+        previous_filtered_frequency_hz,
+        measurement_interval_seconds,
+    )
+    if any(value is not None for value in filter_inputs) and not all(
+        value is not None for value in filter_inputs
+    ):
+        raise ValueError(
+            "frequency_filter_config, previous_filtered_frequency_hz, and "
+            "measurement_interval_seconds must be provided together"
+        )
+    frequency_filter = None
+    control_frequency_hz = frequency_hz
+    if (
+        frequency_filter_config is not None
+        and previous_filtered_frequency_hz is not None
+        and measurement_interval_seconds is not None
+    ):
+        if previous_filtered_frequency_hz <= 0.0:
+            raise ValueError("previous_filtered_frequency_hz must be positive")
+        frequency_filter = filter_first_order_step(
+            frequency_hz,
+            previous_filtered_frequency_hz,
+            measurement_interval_seconds,
+            frequency_filter_config,
+        )
+        control_frequency_hz = frequency_filter.output_value
+
+    adjustment_mw = curve.active_adjustment_mw(control_frequency_hz)
     unconstrained_active_mw = baseline_active_mw + adjustment_mw
     power_bounded_active_mw = max(
         -curve.max_charge_mw,
@@ -193,6 +242,7 @@ def dispatch_frequency_watt(
         )
     return FrequencyWattDispatch(
         frequency_hz=frequency_hz,
+        control_frequency_hz=control_frequency_hz,
         baseline_active_mw=baseline_active_mw,
         droop_adjustment_mw=adjustment_mw,
         unconstrained_active_mw=unconstrained_active_mw,
@@ -200,6 +250,7 @@ def dispatch_frequency_watt(
         ramp_bounded_active_mw=ramp_bounded_active_mw,
         bounded_active_mw=bounded_active_mw,
         storage_power_limited=storage_power_limited,
+        frequency_filter=frequency_filter,
         ramp=ramp,
         energy=energy,
         delivered_energy=delivered_energy,
@@ -225,6 +276,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--full-response-deviation-hz", type=float, default=0.50)
     parser.add_argument("--max-discharge-mw", type=float, default=100.0)
     parser.add_argument("--max-charge-mw", type=float, default=100.0)
+    parser.add_argument("--previous-filtered-frequency-hz", type=float)
+    parser.add_argument("--measurement-interval-seconds", type=float)
+    parser.add_argument("--frequency-filter-time-constant-seconds", type=float)
     parser.add_argument("--previous-active-mw", type=float)
     parser.add_argument("--ramp-interval-seconds", type=float)
     parser.add_argument("--ramp-up-mw-per-minute", type=float)
@@ -306,6 +360,23 @@ def main(argv: Sequence[str] | None = None) -> int:
             args.ramp_up_mw_per_minute,
             args.ramp_down_mw_per_minute,
         )
+    frequency_filter_inputs = (
+        args.previous_filtered_frequency_hz,
+        args.measurement_interval_seconds,
+        args.frequency_filter_time_constant_seconds,
+    )
+    if any(value is not None for value in frequency_filter_inputs) and not all(
+        value is not None for value in frequency_filter_inputs
+    ):
+        raise ValueError(
+            "previous_filtered_frequency_hz, measurement_interval_seconds, and "
+            "frequency_filter_time_constant_seconds must be provided together"
+        )
+    frequency_filter_config = None
+    if args.frequency_filter_time_constant_seconds is not None:
+        frequency_filter_config = FirstOrderFilterConfig(
+            args.frequency_filter_time_constant_seconds
+        )
     result = dispatch_frequency_watt(
         frequency_hz=args.frequency_hz,
         baseline_active_mw=args.baseline_active_mw,
@@ -318,9 +389,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         ramp_limits=ramp_limits,
         previous_active_mw=args.previous_active_mw,
         ramp_interval_seconds=args.ramp_interval_seconds,
+        frequency_filter_config=frequency_filter_config,
+        previous_filtered_frequency_hz=args.previous_filtered_frequency_hz,
+        measurement_interval_seconds=args.measurement_interval_seconds,
     )
     capability = result.capability
     print(f"Frequency: {result.frequency_hz:.3f} Hz")
+    if result.frequency_filter is not None:
+        print(
+            "Previous filtered frequency: "
+            f"{result.frequency_filter.previous_output_value:.3f} Hz"
+        )
+        print(f"Control frequency: {result.control_frequency_hz:.3f} Hz")
+        print(
+            f"Frequency-filter decay factor: {result.frequency_filter.decay_factor:.6f}"
+        )
     print(f"Droop adjustment: {result.droop_adjustment_mw:.3f} MW")
     print(f"Unconstrained active request: {result.unconstrained_active_mw:.3f} MW")
     if result.ramp is not None or result.energy is not None:

--- a/models/measurement_filter.py
+++ b/models/measurement_filter.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class FirstOrderFilterConfig:
+    """Time constant for an exact first-order low-pass filter step."""
+
+    time_constant_seconds: float
+
+    def validate(self) -> None:
+        if (
+            not math.isfinite(self.time_constant_seconds)
+            or self.time_constant_seconds <= 0.0
+        ):
+            raise ValueError("time_constant_seconds must be finite and positive")
+
+
+@dataclass(frozen=True)
+class FirstOrderFilterStep:
+    input_value: float
+    previous_output_value: float
+    output_value: float
+    interval_seconds: float
+    time_constant_seconds: float
+    decay_factor: float
+    input_step: float
+    output_change: float
+
+
+def filter_first_order_step(
+    input_value: float,
+    previous_output_value: float,
+    interval_seconds: float,
+    config: FirstOrderFilterConfig,
+) -> FirstOrderFilterStep:
+    """Apply the exact zero-order-hold solution for one filter interval."""
+
+    config.validate()
+    values = {
+        "input_value": input_value,
+        "previous_output_value": previous_output_value,
+        "interval_seconds": interval_seconds,
+    }
+    for name, value in values.items():
+        if not math.isfinite(value):
+            raise ValueError(f"{name} must be finite")
+    if interval_seconds <= 0.0:
+        raise ValueError("interval_seconds must be positive")
+
+    normalized_interval = interval_seconds / config.time_constant_seconds
+    response_fraction = -math.expm1(-normalized_interval)
+    decay_factor = 1.0 - response_fraction
+    output_value = (
+        previous_output_value
+        + (input_value - previous_output_value) * response_fraction
+    )
+    return FirstOrderFilterStep(
+        input_value=input_value,
+        previous_output_value=previous_output_value,
+        output_value=output_value,
+        interval_seconds=interval_seconds,
+        time_constant_seconds=config.time_constant_seconds,
+        decay_factor=decay_factor,
+        input_step=input_value - previous_output_value,
+        output_change=output_value - previous_output_value,
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Apply one exact first-order low-pass filter step."
+    )
+    parser.add_argument("--input-value", type=float, required=True)
+    parser.add_argument("--previous-output-value", type=float, required=True)
+    parser.add_argument("--interval-seconds", type=float, required=True)
+    parser.add_argument("--time-constant-seconds", type=float, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    result = filter_first_order_step(
+        args.input_value,
+        args.previous_output_value,
+        args.interval_seconds,
+        FirstOrderFilterConfig(args.time_constant_seconds),
+    )
+    print(f"Input value: {result.input_value:.6f}")
+    print(f"Previous output value: {result.previous_output_value:.6f}")
+    print(f"Filtered output value: {result.output_value:.6f}")
+    print(f"Interval: {result.interval_seconds:.6f} seconds")
+    print(f"Time constant: {result.time_constant_seconds:.6f} seconds")
+    print(f"Decay factor: {result.decay_factor:.9f}")
+    print(f"Input step: {result.input_step:.6f}")
+    print(f"Output change: {result.output_change:.6f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_frequency_watt.py
+++ b/tests/test_frequency_watt.py
@@ -11,6 +11,7 @@ from models.frequency_watt import (
     main,
 )
 from models.energy_limits import EnergyBoundary, StorageEnergyState
+from models.measurement_filter import FirstOrderFilterConfig
 from models.pq_capability import PowerPriority
 from models.ramp_limits import RampDirection, RampRateLimits
 
@@ -21,6 +22,59 @@ class FrequencyWattTests(unittest.TestCase):
         self.assertEqual(curve.active_adjustment_mw(49.95), 0.0)
         self.assertEqual(curve.active_adjustment_mw(50.00), 0.0)
         self.assertEqual(curve.active_adjustment_mw(50.05), 0.0)
+
+    def test_frequency_filter_applies_before_droop(self):
+        unfiltered = dispatch_frequency_watt(49.5, 0.0, 0.0, 100.0)
+        filtered = dispatch_frequency_watt(
+            49.5,
+            0.0,
+            0.0,
+            100.0,
+            frequency_filter_config=FirstOrderFilterConfig(1.0),
+            previous_filtered_frequency_hz=50.0,
+            measurement_interval_seconds=0.1,
+        )
+
+        self.assertEqual(unfiltered.droop_adjustment_mw, 100.0)
+        self.assertAlmostEqual(filtered.control_frequency_hz, 49.95241870901798)
+        self.assertEqual(filtered.droop_adjustment_mw, 0.0)
+        self.assertIsNotNone(filtered.frequency_filter)
+        assert filtered.frequency_filter is not None
+        self.assertAlmostEqual(
+            filtered.frequency_filter.decay_factor,
+            math.exp(-0.1),
+        )
+
+    def test_frequency_filter_configuration_is_validated(self):
+        with self.assertRaisesRegex(ValueError, "must be provided together"):
+            dispatch_frequency_watt(
+                49.5,
+                0.0,
+                0.0,
+                100.0,
+                frequency_filter_config=FirstOrderFilterConfig(1.0),
+            )
+        with self.assertRaisesRegex(ValueError, "must be positive"):
+            dispatch_frequency_watt(
+                49.5,
+                0.0,
+                0.0,
+                100.0,
+                frequency_filter_config=FirstOrderFilterConfig(1.0),
+                previous_filtered_frequency_hz=0.0,
+                measurement_interval_seconds=0.1,
+            )
+        with self.assertRaisesRegex(ValueError, "must be provided together"):
+            main(
+                [
+                    "--frequency-hz",
+                    "49.5",
+                    "--limit-mva",
+                    "100",
+                    "--previous-filtered-frequency-hz",
+                    "50",
+                ]
+            )
 
     def test_under_frequency_response_interpolates_and_saturates(self):
         curve = FrequencyWattCurve()
@@ -303,6 +357,34 @@ class FrequencyWattTests(unittest.TestCase):
         self.assertIn("Ramp-bounded active request: 40.000 MW", output)
         self.assertIn("Ramp limited: true", output)
         self.assertIn("Ramp limiting direction: ramp_up", output)
+
+    def test_cli_reports_filtered_control_frequency(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--frequency-hz",
+                    "49.5",
+                    "--baseline-active-mw",
+                    "0",
+                    "--reactive-mvar",
+                    "0",
+                    "--limit-mva",
+                    "100",
+                    "--previous-filtered-frequency-hz",
+                    "50",
+                    "--measurement-interval-seconds",
+                    "0.1",
+                    "--frequency-filter-time-constant-seconds",
+                    "1",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Frequency: 49.500 Hz", output)
+        self.assertIn("Control frequency: 49.952 Hz", output)
+        self.assertIn("Frequency-filter decay factor: 0.904837", output)
+        self.assertIn("Droop adjustment: 0.000 MW", output)
 
     def test_cli_rejects_partial_energy_configuration(self):
         with self.assertRaisesRegex(ValueError, "must be provided together"):

--- a/tests/test_measurement_filter.py
+++ b/tests/test_measurement_filter.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import math
+import unittest
+
+from models.measurement_filter import (
+    FirstOrderFilterConfig,
+    filter_first_order_step,
+    main,
+)
+
+
+class MeasurementFilterTests(unittest.TestCase):
+    def test_step_matches_exact_first_order_solution(self):
+        result = filter_first_order_step(
+            49.0,
+            50.0,
+            1.0,
+            FirstOrderFilterConfig(2.0),
+        )
+        self.assertAlmostEqual(result.decay_factor, math.exp(-0.5), places=15)
+        self.assertAlmostEqual(result.output_value, 49.60653065971263, places=14)
+        self.assertEqual(result.input_step, -1.0)
+        self.assertAlmostEqual(
+            result.output_change,
+            result.output_value - 50.0,
+            places=15,
+        )
+
+    def test_equal_input_and_previous_output_stay_constant(self):
+        result = filter_first_order_step(
+            50.0,
+            50.0,
+            10.0,
+            FirstOrderFilterConfig(0.25),
+        )
+        self.assertEqual(result.output_value, 50.0)
+        self.assertEqual(result.output_change, 0.0)
+
+    def test_tiny_interval_uses_stable_response_fraction(self):
+        result = filter_first_order_step(
+            1.0,
+            0.0,
+            1e-20,
+            FirstOrderFilterConfig(1.0),
+        )
+        self.assertAlmostEqual(result.output_value, 1e-20, places=35)
+        self.assertGreater(result.output_change, 0.0)
+
+    def test_split_intervals_match_one_combined_interval(self):
+        config = FirstOrderFilterConfig(3.0)
+        whole = filter_first_order_step(49.0, 50.0, 2.0, config)
+        first = filter_first_order_step(49.0, 50.0, 0.75, config)
+        second = filter_first_order_step(49.0, first.output_value, 1.25, config)
+        self.assertAlmostEqual(second.output_value, whole.output_value, places=14)
+
+    def test_output_stays_between_previous_output_and_input(self):
+        config = FirstOrderFilterConfig(1.7)
+        for input_value in (-100.0, -1.0, 0.0, 1.0, 100.0):
+            for previous_output in (-50.0, 0.0, 50.0):
+                for interval_seconds in (1e-6, 0.1, 10.0, 1e6):
+                    with self.subTest(
+                        input_value=input_value,
+                        previous_output=previous_output,
+                        interval_seconds=interval_seconds,
+                    ):
+                        result = filter_first_order_step(
+                            input_value,
+                            previous_output,
+                            interval_seconds,
+                            config,
+                        )
+                        self.assertGreaterEqual(
+                            result.output_value,
+                            min(input_value, previous_output),
+                        )
+                        self.assertLessEqual(
+                            result.output_value,
+                            max(input_value, previous_output),
+                        )
+
+    def test_invalid_config_and_inputs_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "time_constant_seconds"):
+            filter_first_order_step(
+                1.0,
+                0.0,
+                1.0,
+                FirstOrderFilterConfig(0.0),
+            )
+        with self.assertRaisesRegex(ValueError, "interval_seconds"):
+            filter_first_order_step(
+                1.0,
+                0.0,
+                0.0,
+                FirstOrderFilterConfig(1.0),
+            )
+        with self.assertRaisesRegex(ValueError, "input_value"):
+            filter_first_order_step(
+                math.nan,
+                0.0,
+                1.0,
+                FirstOrderFilterConfig(1.0),
+            )
+
+    def test_cli_reports_exact_step(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--input-value",
+                    "49",
+                    "--previous-output-value",
+                    "50",
+                    "--interval-seconds",
+                    "1",
+                    "--time-constant-seconds",
+                    "2",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Filtered output value: 49.606531", output)
+        self.assertIn("Decay factor: 0.606530660", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reusable exact first-order low-pass filter step with numerically stable small-interval handling
- apply optional frequency filtering before deadband and droop dispatch
- preserve raw and control frequencies in the result and CLI
- document filter state, sequencing, assumptions, and limitations

## Validation
- `python -m unittest discover -s tests -q` (58 tests)
- `pytest -q` (58 tests, 330 subtests)
- `ruff check` on changed Python files
- `ruff format --check` on changed Python files
- `python -m compileall -q models tests`
- 10,000 randomized filter-and-dispatch oracle cases
- standalone and integrated CLI scenarios