### PR TITLE
Add multi-interval energy trajectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ and project teams.
 - [Executable frequency measurement filter](models/README.md#frequency-measurement-filter)
 - [Executable active-power ramp limits](models/README.md#active-power-ramp-limits)
 - [Executable SOC and response-duration limits](models/README.md#soc-and-response-duration-limits)
+- [Executable multi-interval energy trajectory](models/README.md#multi-interval-energy-trajectory)
 
 - [Grid-forming vs grid-following storage](concepts/grid-forming-vs-grid-following.md)
 - [Grid-code evidence prompt](concepts/grid-code-evidence-prompt.md)
@@ -115,6 +116,12 @@ python models/energy_limits.py `
   --active-mw 100 --duration-minutes 60 `
   --energy-capacity-mwh 50 --initial-soc 0.50 `
   --minimum-soc 0.20 --discharge-efficiency 0.90
+python models/energy_sequence.py `
+  --active-mw-profile 50,50,50,-40 `
+  --duration-minutes-profile 15,15,15,30 `
+  --energy-capacity-mwh 100 --initial-soc 0.50 `
+  --minimum-soc 0.20 --charge-efficiency 0.80 `
+  --discharge-efficiency 1.00
 python -m unittest discover -s tests -v
 ```
 

--- a/models/README.md
+++ b/models/README.md
@@ -251,4 +251,47 @@ active power that remains after P-Q allocation.
 
 This is a single-interval energy accounting reference. It does not model
 self-discharge, auxiliary load, nonlinear efficiency, degradation, thermal
-derating, uncertain capacity, multi-interval scheduling, or SOC recovery.
+derating, or uncertain capacity.
+
+## Multi-Interval Energy Trajectory
+
+[`energy_sequence.py`](energy_sequence.py) carries ending SOC into the next
+requested interval while delegating every power decision to the same
+single-interval limiter. It supports variable durations and preserves the full
+interval result so reviewers can see exactly where a request reached an SOC
+boundary.
+
+Run a four-interval profile that discharges to the minimum SOC boundary and
+then recovers through charging:
+
+```powershell
+python models/energy_sequence.py `
+  --active-mw-profile 50,50,50,-40 `
+  --duration-minutes-profile 15,15,15,30 `
+  --energy-capacity-mwh 100 --initial-soc 0.50 `
+  --minimum-soc 0.20 --charge-efficiency 0.80 `
+  --discharge-efficiency 1.00
+```
+
+Expected summary:
+
+```text
+Intervals: 4
+Limited intervals: 1
+Ending SOC: 0.3600
+Requested AC energy: 17.500 MWh
+Delivered AC energy: 10.000 MWh
+Curtailed AC energy: 7.500 MWh
+Stored energy change: -14.000 MWh
+```
+
+Positive AC energy is net discharge to the grid; negative AC energy is net
+charging. Curtailed energy is the absolute requested-versus-delivered gap, so
+it remains nonnegative in either direction. `soc_balance_error` independently
+reconstructs final SOC from cumulative stored-energy change.
+
+This is a forward audit of a supplied power trajectory, not a scheduler or
+optimizer. It does not choose prices, services, or interval requests, and it
+does not compose frequency, ramp, or P-Q constraints across time. The standing
+loss, auxiliary-load, nonlinear-efficiency, degradation, thermal, and capacity
+limitations of the single-interval model still apply.

--- a/models/energy_sequence.py
+++ b/models/energy_sequence.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass, replace
+from typing import Sequence
+
+try:
+    from models.energy_limits import (
+        EnergyLimitedDispatch,
+        StorageEnergyState,
+        limit_active_power_by_energy,
+    )
+except ModuleNotFoundError:
+    from energy_limits import (
+        EnergyLimitedDispatch,
+        StorageEnergyState,
+        limit_active_power_by_energy,
+    )
+
+
+@dataclass(frozen=True)
+class EnergyDispatchSequence:
+    """Reviewable SOC and energy accounting for a requested power trajectory."""
+
+    intervals: tuple[EnergyLimitedDispatch, ...]
+    initial_soc: float
+    ending_soc: float
+    total_duration_minutes: float
+    requested_ac_energy_mwh: float
+    delivered_ac_energy_mwh: float
+    curtailed_ac_energy_mwh: float
+    stored_energy_change_mwh: float
+    soc_balance_error: float
+    limited_interval_count: int
+
+
+def simulate_energy_dispatch_sequence(
+    requested_active_mw: Sequence[float],
+    duration_minutes: Sequence[float],
+    state: StorageEnergyState,
+) -> EnergyDispatchSequence:
+    """Carry SOC through variable-duration requests using the interval limiter."""
+
+    requests = tuple(requested_active_mw)
+    durations = tuple(duration_minutes)
+    if not requests:
+        raise ValueError("requested_active_mw must contain at least one interval")
+    if len(requests) != len(durations):
+        raise ValueError(
+            "requested_active_mw and duration_minutes must have equal lengths"
+        )
+
+    state.validate()
+    interval_results: list[EnergyLimitedDispatch] = []
+    current_state = state
+    for requested_power_mw, interval_minutes in zip(
+        requests,
+        durations,
+        strict=True,
+    ):
+        interval_result = limit_active_power_by_energy(
+            requested_power_mw,
+            interval_minutes,
+            current_state,
+        )
+        interval_results.append(interval_result)
+        current_state = replace(
+            current_state,
+            initial_soc=interval_result.ending_soc,
+        )
+
+    intervals = tuple(interval_results)
+    requested_ac_energy_mwh = math.fsum(
+        interval.requested_active_mw * interval.duration_minutes / 60.0
+        for interval in intervals
+    )
+    delivered_ac_energy_mwh = math.fsum(
+        interval.delivered_active_mw * interval.duration_minutes / 60.0
+        for interval in intervals
+    )
+    curtailed_ac_energy_mwh = math.fsum(
+        abs(interval.requested_active_mw - interval.delivered_active_mw)
+        * interval.duration_minutes
+        / 60.0
+        for interval in intervals
+    )
+    stored_energy_change_mwh = math.fsum(
+        interval.stored_energy_change_mwh for interval in intervals
+    )
+    ending_soc = intervals[-1].ending_soc
+    expected_ending_soc = (
+        state.initial_soc + stored_energy_change_mwh / state.energy_capacity_mwh
+    )
+
+    return EnergyDispatchSequence(
+        intervals=intervals,
+        initial_soc=state.initial_soc,
+        ending_soc=ending_soc,
+        total_duration_minutes=math.fsum(durations),
+        requested_ac_energy_mwh=requested_ac_energy_mwh,
+        delivered_ac_energy_mwh=delivered_ac_energy_mwh,
+        curtailed_ac_energy_mwh=curtailed_ac_energy_mwh,
+        stored_energy_change_mwh=stored_energy_change_mwh,
+        soc_balance_error=ending_soc - expected_ending_soc,
+        limited_interval_count=sum(interval.energy_limited for interval in intervals),
+    )
+
+
+def _parse_number_series(value: str) -> tuple[float, ...]:
+    raw_values = value.split(",")
+    if not raw_values or any(not raw_value.strip() for raw_value in raw_values):
+        raise argparse.ArgumentTypeError(
+            "profiles must be comma-separated numbers without empty entries"
+        )
+    try:
+        values = tuple(float(raw_value) for raw_value in raw_values)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            "profiles must contain only comma-separated numbers"
+        ) from error
+    if any(not math.isfinite(number) for number in values):
+        raise argparse.ArgumentTypeError("profile values must be finite")
+    return values
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Carry SOC through a requested multi-interval power trajectory."
+    )
+    parser.add_argument(
+        "--active-mw-profile",
+        type=_parse_number_series,
+        required=True,
+    )
+    parser.add_argument(
+        "--duration-minutes-profile",
+        type=_parse_number_series,
+        required=True,
+    )
+    parser.add_argument("--energy-capacity-mwh", type=float, required=True)
+    parser.add_argument("--initial-soc", type=float, required=True)
+    parser.add_argument("--minimum-soc", type=float, default=0.10)
+    parser.add_argument("--maximum-soc", type=float, default=0.90)
+    parser.add_argument("--charge-efficiency", type=float, default=0.95)
+    parser.add_argument("--discharge-efficiency", type=float, default=0.95)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    state = StorageEnergyState(
+        energy_capacity_mwh=args.energy_capacity_mwh,
+        initial_soc=args.initial_soc,
+        minimum_soc=args.minimum_soc,
+        maximum_soc=args.maximum_soc,
+        charge_efficiency=args.charge_efficiency,
+        discharge_efficiency=args.discharge_efficiency,
+    )
+    result = simulate_energy_dispatch_sequence(
+        args.active_mw_profile,
+        args.duration_minutes_profile,
+        state,
+    )
+
+    print(f"Intervals: {len(result.intervals)}")
+    print(f"Limited intervals: {result.limited_interval_count}")
+    print(f"Total duration: {result.total_duration_minutes:.3f} minutes")
+    print(f"Initial SOC: {result.initial_soc:.4f}")
+    print(f"Ending SOC: {result.ending_soc:.4f}")
+    print(f"Requested AC energy: {result.requested_ac_energy_mwh:.3f} MWh")
+    print(f"Delivered AC energy: {result.delivered_ac_energy_mwh:.3f} MWh")
+    print(f"Curtailed AC energy: {result.curtailed_ac_energy_mwh:.3f} MWh")
+    print(f"Stored energy change: {result.stored_energy_change_mwh:.3f} MWh")
+    print(f"SOC balance error: {result.soc_balance_error:.3e}")
+    for interval_index, interval in enumerate(result.intervals, start=1):
+        boundary = (
+            "none"
+            if interval.limiting_boundary is None
+            else interval.limiting_boundary.value
+        )
+        print(
+            f"Interval {interval_index}: "
+            f"requested={interval.requested_active_mw:.3f} MW, "
+            f"delivered={interval.delivered_active_mw:.3f} MW, "
+            f"duration={interval.duration_minutes:.3f} min, "
+            f"ending_soc={interval.ending_soc:.4f}, "
+            f"boundary={boundary}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_energy_sequence.py
+++ b/tests/test_energy_sequence.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import math
+import unittest
+
+from models.energy_limits import StorageEnergyState, limit_active_power_by_energy
+from models.energy_sequence import main, simulate_energy_dispatch_sequence
+
+
+class EnergySequenceTests(unittest.TestCase):
+    def test_variable_intervals_carry_soc_to_a_boundary_and_recover(self):
+        state = StorageEnergyState(
+            energy_capacity_mwh=100.0,
+            initial_soc=0.50,
+            minimum_soc=0.20,
+            maximum_soc=0.90,
+            charge_efficiency=0.80,
+            discharge_efficiency=1.0,
+        )
+        result = simulate_energy_dispatch_sequence(
+            (50.0, 50.0, 50.0, -40.0),
+            (15.0, 15.0, 15.0, 30.0),
+            state,
+        )
+
+        for delivered_active_mw, expected_active_mw in zip(
+            (interval.delivered_active_mw for interval in result.intervals),
+            (50.0, 50.0, 20.0, -40.0),
+            strict=True,
+        ):
+            self.assertAlmostEqual(delivered_active_mw, expected_active_mw)
+        self.assertEqual(result.limited_interval_count, 1)
+        self.assertAlmostEqual(result.total_duration_minutes, 75.0)
+        self.assertAlmostEqual(result.requested_ac_energy_mwh, 17.5)
+        self.assertAlmostEqual(result.delivered_ac_energy_mwh, 10.0)
+        self.assertAlmostEqual(result.curtailed_ac_energy_mwh, 7.5)
+        self.assertAlmostEqual(result.stored_energy_change_mwh, -14.0)
+        self.assertAlmostEqual(result.ending_soc, 0.36)
+        self.assertAlmostEqual(result.soc_balance_error, 0.0)
+
+    def test_single_interval_matches_the_existing_limiter(self):
+        state = StorageEnergyState(
+            energy_capacity_mwh=80.0,
+            initial_soc=0.30,
+            minimum_soc=0.20,
+            discharge_efficiency=0.90,
+        )
+        expected = limit_active_power_by_energy(100.0, 30.0, state)
+        result = simulate_energy_dispatch_sequence((100.0,), (30.0,), state)
+
+        self.assertEqual(result.intervals, (expected,))
+        self.assertEqual(result.initial_soc, state.initial_soc)
+        self.assertEqual(result.ending_soc, expected.ending_soc)
+
+    def test_mixed_profile_closes_stored_energy_and_soc_balance(self):
+        state = StorageEnergyState(
+            energy_capacity_mwh=120.0,
+            initial_soc=0.55,
+            minimum_soc=0.15,
+            maximum_soc=0.85,
+            charge_efficiency=0.92,
+            discharge_efficiency=0.88,
+        )
+        result = simulate_energy_dispatch_sequence(
+            (35.0, -20.0, 0.0, 75.0, -60.0),
+            (10.0, 35.0, 5.0, 20.0, 15.0),
+            state,
+        )
+
+        expected_stored_change = math.fsum(
+            interval.stored_energy_change_mwh for interval in result.intervals
+        )
+        expected_ending_soc = state.initial_soc + (
+            expected_stored_change / state.energy_capacity_mwh
+        )
+        self.assertAlmostEqual(
+            result.stored_energy_change_mwh,
+            expected_stored_change,
+        )
+        self.assertAlmostEqual(result.ending_soc, expected_ending_soc)
+        self.assertAlmostEqual(result.soc_balance_error, 0.0)
+        for previous, current in zip(
+            result.intervals[:-1],
+            result.intervals[1:],
+            strict=True,
+        ):
+            self.assertEqual(previous.ending_soc, current.initial_soc)
+
+    def test_profile_inputs_are_validated(self):
+        state = StorageEnergyState(100.0, 0.50)
+        with self.assertRaisesRegex(ValueError, "at least one interval"):
+            simulate_energy_dispatch_sequence((), (), state)
+        with self.assertRaisesRegex(ValueError, "equal lengths"):
+            simulate_energy_dispatch_sequence((10.0, 20.0), (15.0,), state)
+        with self.assertRaisesRegex(ValueError, "requested_active_mw"):
+            simulate_energy_dispatch_sequence((math.nan,), (15.0,), state)
+        with self.assertRaisesRegex(ValueError, "duration_minutes"):
+            simulate_energy_dispatch_sequence((10.0,), (0.0,), state)
+
+    def test_operating_sweep_stays_inside_soc_limits(self):
+        for initial_soc in (0.10, 0.25, 0.50, 0.75, 0.90):
+            for request_scale in (1.0, 10.0, 100.0):
+                requests = (
+                    2.0 * request_scale,
+                    -request_scale,
+                    0.0,
+                    -3.0 * request_scale,
+                    4.0 * request_scale,
+                )
+                with self.subTest(
+                    initial_soc=initial_soc,
+                    request_scale=request_scale,
+                ):
+                    result = simulate_energy_dispatch_sequence(
+                        requests,
+                        (1.0, 5.0, 15.0, 30.0, 120.0),
+                        StorageEnergyState(100.0, initial_soc),
+                    )
+                    self.assertTrue(
+                        all(
+                            0.10 <= interval.ending_soc <= 0.90
+                            for interval in result.intervals
+                        )
+                    )
+                    self.assertLess(abs(result.soc_balance_error), 1e-12)
+
+    def test_cli_reports_sequence_summary_and_limited_interval(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--active-mw-profile",
+                    "50,50,50,-40",
+                    "--duration-minutes-profile",
+                    "15,15,15,30",
+                    "--energy-capacity-mwh",
+                    "100",
+                    "--initial-soc",
+                    "0.5",
+                    "--minimum-soc",
+                    "0.2",
+                    "--charge-efficiency",
+                    "0.8",
+                    "--discharge-efficiency",
+                    "1",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Intervals: 4", output)
+        self.assertIn("Limited intervals: 1", output)
+        self.assertIn("Ending SOC: 0.3600", output)
+        self.assertIn("Delivered AC energy: 10.000 MWh", output)
+        self.assertIn("Curtailed AC energy: 7.500 MWh", output)
+        self.assertIn(
+            "Interval 3: requested=50.000 MW, delivered=20.000 MW",
+            output,
+        )
+        self.assertIn("boundary=minimum_soc", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- carry SOC through variable-duration active-power requests using the existing interval limiter
- preserve every interval result and expose requested, delivered, curtailed, and stored-energy totals with an independent SOC balance diagnostic
- add a dependency-free CLI, focused regression suite, and documentation that separates trajectory auditing from schedule optimization

## Validation
- `python -m unittest discover -s tests -v` (64 tests)
- Ruff check and format verification for both new Python files
- Python compilation for `models` and `tests`
- `npx --yes markdownlint-cli2 README.md models/README.md`
- documented four-interval CLI scenario
- independent randomized oracle: 10,000 profiles / 65,155 intervals
- `git diff --check`