### PR TITLE
Add stateful multi-service grid support sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ and project teams.
 - [Executable active-power ramp limits](models/README.md#active-power-ramp-limits)
 - [Executable SOC and response-duration limits](models/README.md#soc-and-response-duration-limits)
 - [Executable multi-interval energy trajectory](models/README.md#multi-interval-energy-trajectory)
+- [Executable multi-service grid-support sequence](models/README.md#multi-service-grid-support-sequence)
 
 - [Grid-forming vs grid-following storage](concepts/grid-forming-vs-grid-following.md)
 - [Grid-code evidence prompt](concepts/grid-code-evidence-prompt.md)
@@ -122,6 +123,14 @@ python models/energy_sequence.py `
   --energy-capacity-mwh 100 --initial-soc 0.50 `
   --minimum-soc 0.20 --charge-efficiency 0.80 `
   --discharge-efficiency 1.00
+python models/grid_support_sequence.py `
+  --frequency-hz-profile 50,49.5,50.5 `
+  --voltage-pu-profile 1,0.92,1.08 `
+  --baseline-active-mw-profile 20,20,20 `
+  --duration-minutes-profile 15,15,15 `
+  --limit-mva 100 --energy-capacity-mwh 100 `
+  --initial-soc 0.50 --minimum-soc 0.20 `
+  --charge-efficiency 1 --discharge-efficiency 1
 python -m unittest discover -s tests -v
 ```
 

--- a/models/README.md
+++ b/models/README.md
@@ -295,3 +295,58 @@ optimizer. It does not choose prices, services, or interval requests, and it
 does not compose frequency, ramp, or P-Q constraints across time. The standing
 loss, auxiliary-load, nonlinear-efficiency, degradation, thermal, and capacity
 limitations of the single-interval model still apply.
+
+## Multi-Service Grid-Support Sequence
+
+[`grid_support_sequence.py`](grid_support_sequence.py) composes the existing
+frequency-watt, Volt-VAR, measurement-filter, active-power-ramp, SOC, and
+circular P-Q models over a variable-duration profile. Each interval starts from
+the prior interval's delivered ending SOC. When ramp limits or frequency
+filtering are enabled, it also starts from the prior delivered active power or
+filtered frequency, so curtailment at one control layer changes the next
+interval's reachable state.
+
+Run three simultaneous frequency and voltage events with reactive-power
+priority:
+
+```powershell
+python models/grid_support_sequence.py `
+  --frequency-hz-profile 50,49.5,50.5 `
+  --voltage-pu-profile 1,0.92,1.08 `
+  --baseline-active-mw-profile 20,20,20 `
+  --duration-minutes-profile 15,15,15 `
+  --limit-mva 100 --energy-capacity-mwh 100 `
+  --initial-soc 0.50 --minimum-soc 0.20 `
+  --charge-efficiency 1 --discharge-efficiency 1
+```
+
+Expected summary:
+
+```text
+Intervals: 3
+Limited intervals: 2
+Ending SOC: 0.4500
+Requested active energy: 15.000 MWh
+Delivered active energy: 5.000 MWh
+Active shortfall energy: 50.000 MWh
+Delivered reactive service: 50.000 MVArh
+```
+
+At low voltage and under-frequency, both active and reactive support request
+the full 100-unit capability. The default reactive priority preserves the
+100 MVAr voltage request and curtails active power to zero; delivered-energy
+accounting therefore keeps SOC at 0.45 instead of applying the pre-capability
+active request. `active`, `reactive`, and `proportional` priorities remain
+available for explicit service-conflict studies.
+
+Active-energy totals preserve sign, so charging offsets discharge. Reactive
+service totals sum absolute MVArh because injection and absorption are both
+delivered voltage-support work; each interval row retains the Q direction.
+
+The profile is an auditable control composition, not a dynamic network or
+electromagnetic-transient simulation. Each measurement is held constant for
+its interval. When ramp limits are enabled, they constrain the active setpoint
+before circular P-Q allocation; a higher-priority reactive request may then
+curtail delivered active power beyond that setpoint. Voltage feedback from
+reactive injection, frequency dynamics, controller latency, converter thermal
+limits, degradation, auxiliary demand, and uncertainty remain excluded.

--- a/models/grid_support_sequence.py
+++ b/models/grid_support_sequence.py
@@ -1,0 +1,492 @@
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass, replace
+from typing import Sequence
+
+try:
+    from models.energy_limits import StorageEnergyState
+    from models.frequency_watt import (
+        FrequencyWattCurve,
+        FrequencyWattDispatch,
+        dispatch_frequency_watt,
+    )
+    from models.measurement_filter import FirstOrderFilterConfig
+    from models.pq_capability import PowerPriority
+    from models.ramp_limits import RampRateLimits
+    from models.volt_var import VoltVarCurve
+except ModuleNotFoundError:
+    from energy_limits import StorageEnergyState
+    from frequency_watt import (
+        FrequencyWattCurve,
+        FrequencyWattDispatch,
+        dispatch_frequency_watt,
+    )
+    from measurement_filter import FirstOrderFilterConfig
+    from pq_capability import PowerPriority
+    from ramp_limits import RampRateLimits
+    from volt_var import VoltVarCurve
+
+
+@dataclass(frozen=True)
+class GridSupportInterval:
+    """One state-linked frequency-watt and Volt-VAR dispatch interval."""
+
+    frequency_hz: float
+    voltage_pu: float
+    baseline_active_mw: float
+    duration_minutes: float
+    reactive_request_pu: float
+    requested_reactive_mvar: float
+    initial_soc: float
+    ending_soc: float
+    dispatch: FrequencyWattDispatch
+
+
+@dataclass(frozen=True)
+class GridSupportSequence:
+    """Aggregated service delivery and state accounting for a profile."""
+
+    intervals: tuple[GridSupportInterval, ...]
+    initial_soc: float
+    ending_soc: float
+    total_duration_minutes: float
+    requested_active_energy_mwh: float
+    delivered_active_energy_mwh: float
+    active_shortfall_energy_mwh: float
+    requested_reactive_service_mvarh: float
+    delivered_reactive_service_mvarh: float
+    reactive_shortfall_service_mvarh: float
+    stored_energy_change_mwh: float
+    soc_balance_error: float
+    limited_interval_count: int
+    storage_power_limited_interval_count: int
+    ramp_limited_interval_count: int
+    energy_limited_interval_count: int
+    capability_limited_interval_count: int
+
+
+def _validate_profiles(
+    frequency_hz: Sequence[float],
+    voltage_pu: Sequence[float],
+    baseline_active_mw: Sequence[float],
+    duration_minutes: Sequence[float],
+) -> tuple[tuple[float, ...], tuple[float, ...], tuple[float, ...], tuple[float, ...]]:
+    frequencies = tuple(frequency_hz)
+    voltages = tuple(voltage_pu)
+    baselines = tuple(baseline_active_mw)
+    durations = tuple(duration_minutes)
+    if not frequencies:
+        raise ValueError("profiles must contain at least one interval")
+    profile_lengths = {
+        len(frequencies),
+        len(voltages),
+        len(baselines),
+        len(durations),
+    }
+    if len(profile_lengths) != 1:
+        raise ValueError("all profiles must have equal lengths")
+    for index, duration in enumerate(durations):
+        if not math.isfinite(duration) or duration <= 0.0:
+            raise ValueError(f"duration_minutes[{index}] must be finite and positive")
+    return frequencies, voltages, baselines, durations
+
+
+def simulate_grid_support_sequence(
+    frequency_hz: Sequence[float],
+    voltage_pu: Sequence[float],
+    baseline_active_mw: Sequence[float],
+    duration_minutes: Sequence[float],
+    energy_state: StorageEnergyState,
+    apparent_power_limit_mva: float,
+    frequency_curve: FrequencyWattCurve = FrequencyWattCurve(),
+    voltage_curve: VoltVarCurve = VoltVarCurve(),
+    reactive_base_mvar: float | None = None,
+    priority: PowerPriority | str = PowerPriority.REACTIVE,
+    ramp_limits: RampRateLimits | None = None,
+    initial_active_mw: float | None = None,
+    frequency_filter_config: FirstOrderFilterConfig | None = None,
+    initial_filtered_frequency_hz: float | None = None,
+) -> GridSupportSequence:
+    """Compose grid-support controls while carrying plant state between intervals."""
+
+    frequencies, voltages, baselines, durations = _validate_profiles(
+        frequency_hz,
+        voltage_pu,
+        baseline_active_mw,
+        duration_minutes,
+    )
+    energy_state.validate()
+    frequency_curve.validate()
+    voltage_curve.validate()
+    if not math.isfinite(apparent_power_limit_mva) or apparent_power_limit_mva <= 0.0:
+        raise ValueError("apparent_power_limit_mva must be finite and positive")
+    base_mvar = (
+        apparent_power_limit_mva if reactive_base_mvar is None else reactive_base_mvar
+    )
+    if not math.isfinite(base_mvar) or base_mvar <= 0.0:
+        raise ValueError("reactive_base_mvar must be finite and positive")
+
+    if (ramp_limits is None) != (initial_active_mw is None):
+        raise ValueError("ramp_limits and initial_active_mw must be provided together")
+    if ramp_limits is not None:
+        ramp_limits.validate()
+        assert initial_active_mw is not None
+        if not math.isfinite(initial_active_mw):
+            raise ValueError("initial_active_mw must be finite")
+    if (frequency_filter_config is None) != (initial_filtered_frequency_hz is None):
+        raise ValueError(
+            "frequency_filter_config and initial_filtered_frequency_hz "
+            "must be provided together"
+        )
+    if frequency_filter_config is not None:
+        frequency_filter_config.validate()
+        assert initial_filtered_frequency_hz is not None
+        if (
+            not math.isfinite(initial_filtered_frequency_hz)
+            or initial_filtered_frequency_hz <= 0.0
+        ):
+            raise ValueError(
+                "initial_filtered_frequency_hz must be finite and positive"
+            )
+
+    current_energy_state = energy_state
+    previous_active_mw = initial_active_mw
+    previous_filtered_frequency_hz = initial_filtered_frequency_hz
+    interval_results: list[GridSupportInterval] = []
+    for frequency, voltage, baseline, duration in zip(
+        frequencies,
+        voltages,
+        baselines,
+        durations,
+        strict=True,
+    ):
+        request_pu = voltage_curve.reactive_request_pu(voltage)
+        requested_reactive_mvar = request_pu * base_mvar
+        dispatch = dispatch_frequency_watt(
+            frequency_hz=frequency,
+            baseline_active_mw=baseline,
+            reactive_power_mvar=requested_reactive_mvar,
+            apparent_power_limit_mva=apparent_power_limit_mva,
+            curve=frequency_curve,
+            priority=priority,
+            energy_state=current_energy_state,
+            duration_minutes=duration,
+            ramp_limits=ramp_limits,
+            previous_active_mw=previous_active_mw,
+            ramp_interval_seconds=(None if ramp_limits is None else duration * 60.0),
+            frequency_filter_config=frequency_filter_config,
+            previous_filtered_frequency_hz=previous_filtered_frequency_hz,
+            measurement_interval_seconds=(
+                None if frequency_filter_config is None else duration * 60.0
+            ),
+        )
+        assert dispatch.delivered_energy is not None
+        delivered_energy = dispatch.delivered_energy
+        interval_results.append(
+            GridSupportInterval(
+                frequency_hz=frequency,
+                voltage_pu=voltage,
+                baseline_active_mw=baseline,
+                duration_minutes=duration,
+                reactive_request_pu=request_pu,
+                requested_reactive_mvar=requested_reactive_mvar,
+                initial_soc=delivered_energy.initial_soc,
+                ending_soc=delivered_energy.ending_soc,
+                dispatch=dispatch,
+            )
+        )
+        current_energy_state = replace(
+            current_energy_state,
+            initial_soc=delivered_energy.ending_soc,
+        )
+        if ramp_limits is not None:
+            previous_active_mw = dispatch.capability.active_mw
+        if frequency_filter_config is not None:
+            previous_filtered_frequency_hz = dispatch.control_frequency_hz
+
+    intervals = tuple(interval_results)
+    requested_active_energy_mwh = math.fsum(
+        interval.dispatch.unconstrained_active_mw * interval.duration_minutes / 60.0
+        for interval in intervals
+    )
+    delivered_active_energy_mwh = math.fsum(
+        interval.dispatch.capability.active_mw * interval.duration_minutes / 60.0
+        for interval in intervals
+    )
+    active_shortfall_energy_mwh = math.fsum(
+        abs(
+            interval.dispatch.unconstrained_active_mw
+            - interval.dispatch.capability.active_mw
+        )
+        * interval.duration_minutes
+        / 60.0
+        for interval in intervals
+    )
+    requested_reactive_service_mvarh = math.fsum(
+        abs(interval.requested_reactive_mvar) * interval.duration_minutes / 60.0
+        for interval in intervals
+    )
+    delivered_reactive_service_mvarh = math.fsum(
+        abs(interval.dispatch.capability.reactive_mvar)
+        * interval.duration_minutes
+        / 60.0
+        for interval in intervals
+    )
+    reactive_shortfall_service_mvarh = math.fsum(
+        abs(
+            interval.requested_reactive_mvar
+            - interval.dispatch.capability.reactive_mvar
+        )
+        * interval.duration_minutes
+        / 60.0
+        for interval in intervals
+    )
+    stored_energy_change_mwh = math.fsum(
+        interval.dispatch.delivered_energy.stored_energy_change_mwh
+        for interval in intervals
+        if interval.dispatch.delivered_energy is not None
+    )
+    ending_soc = intervals[-1].ending_soc
+    expected_ending_soc = (
+        energy_state.initial_soc
+        + stored_energy_change_mwh / energy_state.energy_capacity_mwh
+    )
+
+    def interval_is_limited(interval: GridSupportInterval) -> bool:
+        dispatch = interval.dispatch
+        return (
+            dispatch.storage_power_limited
+            or (dispatch.ramp is not None and dispatch.ramp.ramp_limited)
+            or (dispatch.energy is not None and dispatch.energy.energy_limited)
+            or dispatch.capability.limited
+        )
+
+    return GridSupportSequence(
+        intervals=intervals,
+        initial_soc=energy_state.initial_soc,
+        ending_soc=ending_soc,
+        total_duration_minutes=math.fsum(durations),
+        requested_active_energy_mwh=requested_active_energy_mwh,
+        delivered_active_energy_mwh=delivered_active_energy_mwh,
+        active_shortfall_energy_mwh=active_shortfall_energy_mwh,
+        requested_reactive_service_mvarh=requested_reactive_service_mvarh,
+        delivered_reactive_service_mvarh=delivered_reactive_service_mvarh,
+        reactive_shortfall_service_mvarh=reactive_shortfall_service_mvarh,
+        stored_energy_change_mwh=stored_energy_change_mwh,
+        soc_balance_error=ending_soc - expected_ending_soc,
+        limited_interval_count=sum(interval_is_limited(item) for item in intervals),
+        storage_power_limited_interval_count=sum(
+            item.dispatch.storage_power_limited for item in intervals
+        ),
+        ramp_limited_interval_count=sum(
+            item.dispatch.ramp is not None and item.dispatch.ramp.ramp_limited
+            for item in intervals
+        ),
+        energy_limited_interval_count=sum(
+            item.dispatch.energy is not None and item.dispatch.energy.energy_limited
+            for item in intervals
+        ),
+        capability_limited_interval_count=sum(
+            item.dispatch.capability.limited for item in intervals
+        ),
+    )
+
+
+def _parse_number_series(value: str) -> tuple[float, ...]:
+    raw_values = value.split(",")
+    if not raw_values or any(not raw_value.strip() for raw_value in raw_values):
+        raise argparse.ArgumentTypeError(
+            "profiles must be comma-separated numbers without empty entries"
+        )
+    try:
+        values = tuple(float(raw_value) for raw_value in raw_values)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            "profiles must contain only comma-separated numbers"
+        ) from error
+    if any(not math.isfinite(number) for number in values):
+        raise argparse.ArgumentTypeError("profile values must be finite")
+    return values
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Simulate state-linked frequency-watt and Volt-VAR support intervals."
+        )
+    )
+    parser.add_argument(
+        "--frequency-hz-profile", type=_parse_number_series, required=True
+    )
+    parser.add_argument(
+        "--voltage-pu-profile", type=_parse_number_series, required=True
+    )
+    parser.add_argument("--baseline-active-mw-profile", type=_parse_number_series)
+    parser.add_argument(
+        "--duration-minutes-profile", type=_parse_number_series, required=True
+    )
+    parser.add_argument("--limit-mva", type=float, required=True)
+    parser.add_argument("--energy-capacity-mwh", type=float, required=True)
+    parser.add_argument("--initial-soc", type=float, required=True)
+    parser.add_argument("--minimum-soc", type=float, default=0.10)
+    parser.add_argument("--maximum-soc", type=float, default=0.90)
+    parser.add_argument("--charge-efficiency", type=float, default=0.95)
+    parser.add_argument("--discharge-efficiency", type=float, default=0.95)
+    parser.add_argument("--reactive-base-mvar", type=float)
+    parser.add_argument(
+        "--priority",
+        choices=[item.value for item in PowerPriority],
+        default=PowerPriority.REACTIVE.value,
+    )
+    parser.add_argument("--nominal-frequency-hz", type=float, default=50.0)
+    parser.add_argument("--frequency-deadband-hz", type=float, default=0.05)
+    parser.add_argument("--full-response-deviation-hz", type=float, default=0.50)
+    parser.add_argument("--max-discharge-mw", type=float, default=100.0)
+    parser.add_argument("--max-charge-mw", type=float, default=100.0)
+    parser.add_argument("--low-saturation-pu", type=float, default=0.92)
+    parser.add_argument("--low-deadband-pu", type=float, default=0.98)
+    parser.add_argument("--high-deadband-pu", type=float, default=1.02)
+    parser.add_argument("--high-saturation-pu", type=float, default=1.08)
+    parser.add_argument("--max-reactive-power-pu", type=float, default=1.0)
+    parser.add_argument("--initial-active-mw", type=float)
+    parser.add_argument("--ramp-up-mw-per-minute", type=float)
+    parser.add_argument("--ramp-down-mw-per-minute", type=float)
+    parser.add_argument("--initial-filtered-frequency-hz", type=float)
+    parser.add_argument("--frequency-filter-time-constant-seconds", type=float)
+    return parser.parse_args(argv)
+
+
+def _limit_labels(interval: GridSupportInterval) -> str:
+    labels: list[str] = []
+    dispatch = interval.dispatch
+    if dispatch.storage_power_limited:
+        labels.append("storage_power")
+    if dispatch.ramp is not None and dispatch.ramp.ramp_limited:
+        labels.append("ramp")
+    if dispatch.energy is not None and dispatch.energy.energy_limited:
+        labels.append("energy")
+    if dispatch.capability.limited:
+        labels.append("capability")
+    return ",".join(labels) if labels else "none"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    interval_count = len(args.frequency_hz_profile)
+    baselines = args.baseline_active_mw_profile
+    if baselines is None:
+        baselines = (0.0,) * interval_count
+
+    ramp_inputs = (
+        args.initial_active_mw,
+        args.ramp_up_mw_per_minute,
+        args.ramp_down_mw_per_minute,
+    )
+    if any(value is not None for value in ramp_inputs) and not all(
+        value is not None for value in ramp_inputs
+    ):
+        raise ValueError(
+            "initial_active_mw, ramp_up_mw_per_minute, and "
+            "ramp_down_mw_per_minute must be provided together"
+        )
+    ramp_limits = None
+    if args.ramp_up_mw_per_minute is not None:
+        ramp_limits = RampRateLimits(
+            args.ramp_up_mw_per_minute,
+            args.ramp_down_mw_per_minute,
+        )
+
+    filter_inputs = (
+        args.initial_filtered_frequency_hz,
+        args.frequency_filter_time_constant_seconds,
+    )
+    if any(value is not None for value in filter_inputs) and not all(
+        value is not None for value in filter_inputs
+    ):
+        raise ValueError(
+            "initial_filtered_frequency_hz and "
+            "frequency_filter_time_constant_seconds must be provided together"
+        )
+    filter_config = None
+    if args.frequency_filter_time_constant_seconds is not None:
+        filter_config = FirstOrderFilterConfig(
+            args.frequency_filter_time_constant_seconds
+        )
+
+    result = simulate_grid_support_sequence(
+        frequency_hz=args.frequency_hz_profile,
+        voltage_pu=args.voltage_pu_profile,
+        baseline_active_mw=baselines,
+        duration_minutes=args.duration_minutes_profile,
+        energy_state=StorageEnergyState(
+            energy_capacity_mwh=args.energy_capacity_mwh,
+            initial_soc=args.initial_soc,
+            minimum_soc=args.minimum_soc,
+            maximum_soc=args.maximum_soc,
+            charge_efficiency=args.charge_efficiency,
+            discharge_efficiency=args.discharge_efficiency,
+        ),
+        apparent_power_limit_mva=args.limit_mva,
+        frequency_curve=FrequencyWattCurve(
+            nominal_frequency_hz=args.nominal_frequency_hz,
+            deadband_hz=args.frequency_deadband_hz,
+            full_response_deviation_hz=args.full_response_deviation_hz,
+            max_discharge_mw=args.max_discharge_mw,
+            max_charge_mw=args.max_charge_mw,
+        ),
+        voltage_curve=VoltVarCurve(
+            low_saturation_pu=args.low_saturation_pu,
+            low_deadband_pu=args.low_deadband_pu,
+            high_deadband_pu=args.high_deadband_pu,
+            high_saturation_pu=args.high_saturation_pu,
+            max_reactive_power_pu=args.max_reactive_power_pu,
+        ),
+        reactive_base_mvar=args.reactive_base_mvar,
+        priority=args.priority,
+        ramp_limits=ramp_limits,
+        initial_active_mw=args.initial_active_mw,
+        frequency_filter_config=filter_config,
+        initial_filtered_frequency_hz=args.initial_filtered_frequency_hz,
+    )
+
+    print(f"Intervals: {len(result.intervals)}")
+    print(f"Limited intervals: {result.limited_interval_count}")
+    print(f"Total duration: {result.total_duration_minutes:.3f} minutes")
+    print(f"Initial SOC: {result.initial_soc:.4f}")
+    print(f"Ending SOC: {result.ending_soc:.4f}")
+    print(f"Requested active energy: {result.requested_active_energy_mwh:.3f} MWh")
+    print(f"Delivered active energy: {result.delivered_active_energy_mwh:.3f} MWh")
+    print(f"Active shortfall energy: {result.active_shortfall_energy_mwh:.3f} MWh")
+    print(
+        "Requested reactive service: "
+        f"{result.requested_reactive_service_mvarh:.3f} MVArh"
+    )
+    print(
+        "Delivered reactive service: "
+        f"{result.delivered_reactive_service_mvarh:.3f} MVArh"
+    )
+    print(
+        "Reactive shortfall service: "
+        f"{result.reactive_shortfall_service_mvarh:.3f} MVArh"
+    )
+    print(f"Stored energy change: {result.stored_energy_change_mwh:.3f} MWh")
+    print(f"SOC balance error: {result.soc_balance_error:.3e}")
+    for index, interval in enumerate(result.intervals, start=1):
+        dispatch = interval.dispatch
+        print(
+            f"Interval {index}: frequency={interval.frequency_hz:.3f} Hz, "
+            f"voltage={interval.voltage_pu:.3f} pu, "
+            f"requested_p={dispatch.unconstrained_active_mw:.3f} MW, "
+            f"requested_q={interval.requested_reactive_mvar:.3f} MVAr, "
+            f"delivered_p={dispatch.capability.active_mw:.3f} MW, "
+            f"delivered_q={dispatch.capability.reactive_mvar:.3f} MVAr, "
+            f"ending_soc={interval.ending_soc:.4f}, "
+            f"limits={_limit_labels(interval)}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_grid_support_sequence.py
+++ b/tests/test_grid_support_sequence.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import math
+import unittest
+
+from models.energy_limits import StorageEnergyState
+from models.frequency_watt import dispatch_frequency_watt
+from models.grid_support_sequence import main, simulate_grid_support_sequence
+from models.measurement_filter import FirstOrderFilterConfig
+from models.pq_capability import PowerPriority
+from models.ramp_limits import RampRateLimits
+from models.volt_var import VoltVarCurve
+
+
+class GridSupportSequenceTests(unittest.TestCase):
+    def test_simultaneous_services_carry_delivered_soc(self):
+        result = simulate_grid_support_sequence(
+            frequency_hz=(50.0, 49.5, 50.5),
+            voltage_pu=(1.0, 0.92, 1.08),
+            baseline_active_mw=(20.0, 20.0, 20.0),
+            duration_minutes=(15.0, 15.0, 15.0),
+            energy_state=StorageEnergyState(
+                100.0,
+                0.50,
+                minimum_soc=0.20,
+                charge_efficiency=1.0,
+                discharge_efficiency=1.0,
+            ),
+            apparent_power_limit_mva=100.0,
+        )
+
+        self.assertAlmostEqual(result.intervals[0].dispatch.capability.active_mw, 20.0)
+        self.assertAlmostEqual(result.intervals[0].ending_soc, 0.45)
+        self.assertAlmostEqual(
+            result.intervals[1].dispatch.unconstrained_active_mw,
+            120.0,
+        )
+        self.assertAlmostEqual(
+            result.intervals[1].dispatch.capability.reactive_mvar,
+            100.0,
+        )
+        self.assertAlmostEqual(result.intervals[1].dispatch.capability.active_mw, 0.0)
+        self.assertAlmostEqual(result.intervals[1].initial_soc, 0.45)
+        self.assertAlmostEqual(result.intervals[1].ending_soc, 0.45)
+        self.assertAlmostEqual(result.intervals[2].initial_soc, 0.45)
+        self.assertAlmostEqual(result.ending_soc, 0.45)
+        self.assertAlmostEqual(result.requested_active_energy_mwh, 15.0)
+        self.assertAlmostEqual(result.delivered_active_energy_mwh, 5.0)
+        self.assertAlmostEqual(result.active_shortfall_energy_mwh, 50.0)
+        self.assertAlmostEqual(result.requested_reactive_service_mvarh, 50.0)
+        self.assertAlmostEqual(result.delivered_reactive_service_mvarh, 50.0)
+        self.assertAlmostEqual(result.reactive_shortfall_service_mvarh, 0.0)
+        self.assertEqual(result.storage_power_limited_interval_count, 1)
+        self.assertEqual(result.capability_limited_interval_count, 2)
+        self.assertEqual(result.limited_interval_count, 2)
+
+    def test_single_interval_matches_composed_existing_models(self):
+        voltage_curve = VoltVarCurve()
+        energy_state = StorageEnergyState(100.0, 0.50)
+        reactive_request = voltage_curve.reactive_request_pu(0.95) * 100.0
+        expected = dispatch_frequency_watt(
+            49.725,
+            20.0,
+            reactive_request,
+            100.0,
+            priority=PowerPriority.ACTIVE,
+            energy_state=energy_state,
+            duration_minutes=15.0,
+        )
+        result = simulate_grid_support_sequence(
+            (49.725,),
+            (0.95,),
+            (20.0,),
+            (15.0,),
+            energy_state,
+            100.0,
+            priority=PowerPriority.ACTIVE,
+        )
+
+        self.assertEqual(result.intervals[0].dispatch, expected)
+        self.assertAlmostEqual(result.intervals[0].requested_reactive_mvar, 50.0)
+
+    def test_soc_boundaries_carry_between_opposite_responses(self):
+        result = simulate_grid_support_sequence(
+            (49.5, 50.5),
+            (1.0, 1.0),
+            (0.0, 0.0),
+            (60.0, 60.0),
+            StorageEnergyState(
+                100.0,
+                0.21,
+                minimum_soc=0.20,
+                maximum_soc=0.90,
+                charge_efficiency=1.0,
+                discharge_efficiency=1.0,
+            ),
+            100.0,
+        )
+
+        first, second = result.intervals
+        self.assertAlmostEqual(first.dispatch.capability.active_mw, 1.0)
+        self.assertAlmostEqual(first.ending_soc, 0.20)
+        self.assertAlmostEqual(second.initial_soc, 0.20)
+        self.assertAlmostEqual(second.dispatch.capability.active_mw, -70.0)
+        self.assertAlmostEqual(second.ending_soc, 0.90)
+        self.assertEqual(result.energy_limited_interval_count, 2)
+        self.assertAlmostEqual(result.soc_balance_error, 0.0)
+
+    def test_ramp_and_filter_states_are_carried(self):
+        result = simulate_grid_support_sequence(
+            (49.0, 49.0),
+            (1.0, 1.0),
+            (0.0, 0.0),
+            (0.5, 0.5),
+            StorageEnergyState(100.0, 0.50),
+            100.0,
+            ramp_limits=RampRateLimits(10.0, 20.0),
+            initial_active_mw=0.0,
+            frequency_filter_config=FirstOrderFilterConfig(60.0),
+            initial_filtered_frequency_hz=50.0,
+        )
+
+        first, second = result.intervals
+        assert first.dispatch.ramp is not None
+        assert second.dispatch.ramp is not None
+        assert first.dispatch.frequency_filter is not None
+        assert second.dispatch.frequency_filter is not None
+        self.assertAlmostEqual(first.dispatch.capability.active_mw, 5.0)
+        self.assertAlmostEqual(second.dispatch.ramp.previous_active_mw, 5.0)
+        self.assertAlmostEqual(second.dispatch.capability.active_mw, 10.0)
+        self.assertAlmostEqual(
+            second.dispatch.frequency_filter.previous_output_value,
+            first.dispatch.control_frequency_hz,
+        )
+        self.assertEqual(result.ramp_limited_interval_count, 2)
+
+    def test_aggregate_service_and_soc_balances_close(self):
+        state = StorageEnergyState(
+            120.0,
+            0.55,
+            minimum_soc=0.15,
+            maximum_soc=0.85,
+            charge_efficiency=0.92,
+            discharge_efficiency=0.88,
+        )
+        result = simulate_grid_support_sequence(
+            (49.8, 50.2, 50.0, 49.5),
+            (0.95, 1.05, 1.0, 0.90),
+            (10.0, -10.0, 5.0, 0.0),
+            (5.0, 10.0, 15.0, 20.0),
+            state,
+            75.0,
+            priority=PowerPriority.PROPORTIONAL,
+        )
+
+        expected_stored_change = math.fsum(
+            interval.dispatch.delivered_energy.stored_energy_change_mwh
+            for interval in result.intervals
+            if interval.dispatch.delivered_energy is not None
+        )
+        self.assertAlmostEqual(result.stored_energy_change_mwh, expected_stored_change)
+        self.assertAlmostEqual(
+            result.ending_soc,
+            state.initial_soc + expected_stored_change / state.energy_capacity_mwh,
+        )
+        self.assertAlmostEqual(result.soc_balance_error, 0.0)
+        self.assertGreaterEqual(result.active_shortfall_energy_mwh, 0.0)
+        self.assertGreaterEqual(result.reactive_shortfall_service_mvarh, 0.0)
+
+    def test_profile_and_optional_state_inputs_are_validated(self):
+        state = StorageEnergyState(100.0, 0.50)
+        with self.assertRaisesRegex(ValueError, "at least one interval"):
+            simulate_grid_support_sequence((), (), (), (), state, 100.0)
+        with self.assertRaisesRegex(ValueError, "equal lengths"):
+            simulate_grid_support_sequence(
+                (50.0, 50.0),
+                (1.0,),
+                (0.0, 0.0),
+                (1.0, 1.0),
+                state,
+                100.0,
+            )
+        with self.assertRaisesRegex(ValueError, r"duration_minutes\[0\]"):
+            simulate_grid_support_sequence(
+                (50.0,), (1.0,), (0.0,), (0.0,), state, 100.0
+            )
+        with self.assertRaisesRegex(ValueError, "ramp_limits"):
+            simulate_grid_support_sequence(
+                (50.0,),
+                (1.0,),
+                (0.0,),
+                (1.0,),
+                state,
+                100.0,
+                ramp_limits=RampRateLimits(1.0, 1.0),
+            )
+        with self.assertRaisesRegex(ValueError, "frequency_filter_config"):
+            simulate_grid_support_sequence(
+                (50.0,),
+                (1.0,),
+                (0.0,),
+                (1.0,),
+                state,
+                100.0,
+                initial_filtered_frequency_hz=50.0,
+            )
+
+    def test_operating_sweep_respects_soc_and_capability_boundaries(self):
+        frequencies = (49.0, 49.8, 50.0, 50.2, 51.0)
+        voltages = (0.90, 0.95, 1.0, 1.05, 1.10)
+        for initial_soc in (0.10, 0.50, 0.90):
+            for priority in PowerPriority:
+                with self.subTest(initial_soc=initial_soc, priority=priority):
+                    result = simulate_grid_support_sequence(
+                        frequencies,
+                        voltages,
+                        (-80.0, -20.0, 0.0, 20.0, 80.0),
+                        (1.0, 5.0, 15.0, 30.0, 60.0),
+                        StorageEnergyState(100.0, initial_soc),
+                        100.0,
+                        priority=priority,
+                        ramp_limits=RampRateLimits(200.0, 150.0),
+                        initial_active_mw=0.0,
+                    )
+                    for previous, current in zip(
+                        result.intervals[:-1],
+                        result.intervals[1:],
+                        strict=True,
+                    ):
+                        self.assertAlmostEqual(previous.ending_soc, current.initial_soc)
+                        assert current.dispatch.ramp is not None
+                        self.assertAlmostEqual(
+                            current.dispatch.ramp.previous_active_mw,
+                            previous.dispatch.capability.active_mw,
+                        )
+                    for interval in result.intervals:
+                        self.assertGreaterEqual(interval.ending_soc, 0.10 - 1e-12)
+                        self.assertLessEqual(interval.ending_soc, 0.90 + 1e-12)
+                        self.assertLessEqual(
+                            interval.dispatch.capability.apparent_power_mva,
+                            100.0 + 1e-12,
+                        )
+                    self.assertLess(abs(result.soc_balance_error), 1e-12)
+
+    def test_cli_reports_interval_limits_and_aggregate_delivery(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--frequency-hz-profile",
+                    "50,49.5,50.5",
+                    "--voltage-pu-profile",
+                    "1,0.92,1.08",
+                    "--baseline-active-mw-profile",
+                    "20,20,20",
+                    "--duration-minutes-profile",
+                    "15,15,15",
+                    "--limit-mva",
+                    "100",
+                    "--energy-capacity-mwh",
+                    "100",
+                    "--initial-soc",
+                    "0.5",
+                    "--minimum-soc",
+                    "0.2",
+                    "--charge-efficiency",
+                    "1",
+                    "--discharge-efficiency",
+                    "1",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Intervals: 3", output)
+        self.assertIn("Limited intervals: 2", output)
+        self.assertIn("Ending SOC: 0.4500", output)
+        self.assertIn("Delivered active energy: 5.000 MWh", output)
+        self.assertIn("Active shortfall energy: 50.000 MWh", output)
+        self.assertIn("Delivered reactive service: 50.000 MVArh", output)
+        self.assertIn(
+            "Interval 2: frequency=49.500 Hz, voltage=0.920 pu",
+            output,
+        )
+        self.assertIn("limits=storage_power,capability", output)
+
+    def test_cli_rejects_partial_ramp_and_filter_configuration(self):
+        common = [
+            "--frequency-hz-profile",
+            "50",
+            "--voltage-pu-profile",
+            "1",
+            "--duration-minutes-profile",
+            "1",
+            "--limit-mva",
+            "100",
+            "--energy-capacity-mwh",
+            "100",
+            "--initial-soc",
+            "0.5",
+        ]
+        with self.assertRaisesRegex(ValueError, "must be provided together"):
+            main(common + ["--initial-active-mw", "0"])
+        with self.assertRaisesRegex(ValueError, "must be provided together"):
+            main(common + ["--initial-filtered-frequency-hz", "50"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- compose frequency-watt, Volt-VAR, ramp, SOC, filtering, and circular P-Q controls over variable-duration profiles
- carry delivered SOC, active power, and filtered frequency into subsequent intervals while preserving each underlying stage result
- report aggregate active-energy and reactive-service delivery, shortfalls, limit counts, and SOC balance closure
- document a simultaneous frequency/voltage conflict example and explicit model limitations

## Validation
- `python -m unittest discover -s tests -v` (73 tests)
- Ruff check and target format check
- Python compilation
- Markdown lint and local link checks
- documented three-interval CLI scenario
- independent 10,000-profile / 49,615-interval randomized oracle with zero state-link and aggregate errors