### PR TITLE
Add sampled P-Q capability envelope

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "**.md"
       - "**.py"
+      - "models/**/*.csv"
       - ".github/workflows/markdown-maintenance.yml"
   push:
     branches:
@@ -13,6 +14,7 @@ on:
     paths:
       - "**.md"
       - "**.py"
+      - "models/**/*.csv"
       - ".github/workflows/markdown-maintenance.yml"
 
 permissions:
@@ -32,6 +34,13 @@ jobs:
 
       - name: Test executable models
         run: python -m unittest discover -s tests -v
+
+      - name: Run sampled capability envelope
+        run: >-
+          python models/pq_capability.py
+          --active-mw 80 --reactive-mvar 80
+          --curve-csv models/data/illustrative_capability_curve.csv
+          --priority active
 
       - name: Check Markdown links
         uses: lycheeverse/lychee-action@v2

--- a/README.md
+++ b/README.md
@@ -97,11 +97,15 @@ LICENSE
 ## Run The Executable Reference
 
 The dependency-free allocator demonstrates active-priority, reactive-priority,
-and proportional handling of commands outside a circular MVA limit:
+and proportional handling of commands outside a circular MVA limit or sampled
+piecewise P-Q envelope:
 
 ```powershell
 python models/pq_capability.py `
   --active-mw 80 --reactive-mvar 80 --limit-mva 100 --priority active
+python models/pq_capability.py `
+  --active-mw 80 --reactive-mvar 80 `
+  --curve-csv models/data/illustrative_capability_curve.csv --priority active
 python models/volt_var.py `
   --voltage-pu 0.95 --active-mw 90 --limit-mva 100
 python models/frequency_watt.py `

--- a/models/README.md
+++ b/models/README.md
@@ -1,8 +1,9 @@
 # Active/Reactive Capability Reference
 
 This dependency-free Python example makes constrained active/reactive power
-priority explicit. It applies a circular inverter capability limit and reports
-the delivered command, curtailed command, apparent power, and utilization.
+priority explicit. It applies either a circular inverter capability limit or a
+sampled piecewise envelope and reports the delivered command, curtailed
+command, apparent power, and utilization.
 
 ## Capability Rule
 
@@ -20,6 +21,11 @@ follows:
 - `reactive`: preserve reactive power first and use remaining headroom for
   active power; or
 - `proportional`: scale active and reactive power by the same factor.
+
+The optional CSV envelope samples the positive-quadrant boundary as strictly
+increasing active power and strictly decreasing reactive limit. The loader
+requires reactive-axis and active-axis endpoints plus a concave piecewise-linear
+shape. Allocation mirrors that boundary into all four quadrants.
 
 ## Run A Constrained Example
 
@@ -40,6 +46,25 @@ Apparent power: 100.000 MVA
 Capability utilization: 100.00%
 ```
 
+Run the committed noncircular example with the same priority policies:
+
+```powershell
+python models/pq_capability.py `
+  --active-mw 80 `
+  --reactive-mvar 80 `
+  --curve-csv models/data/illustrative_capability_curve.csv `
+  --priority active
+```
+
+The sampled boundary limits the 80 MW request to 50 MVAr:
+
+```text
+Capability model: piecewise curve (4 points)
+Active power: 80.000 MW
+Reactive power: 50.000 MVAr
+Capability utilization: 100.00%
+```
+
 Run the regression checks with:
 
 ```powershell
@@ -48,10 +73,14 @@ python -m unittest discover -s tests -v
 
 ## Explicit Limitations
 
-- The capability boundary is a fixed circle rather than a manufacturer curve.
+- The sampled curve is quadrant-symmetric, concave, and linearly interpolated.
+  Use separate project logic for asymmetric charge/discharge or reactive
+  injection/absorption limits.
 - Dynamic current limits, voltage dependence, and temperature derating are
-  excluded. SOC and interval-duration limits can be composed through
-  `energy_limits.py`, but are not inherent to the P-Q allocator.
+  not calculated internally. They can be represented only after an external
+  study supplies the applicable sampled envelope. SOC and interval-duration
+  limits can be composed through `energy_limits.py`, but are not inherent to
+  the P-Q allocator.
 - The allocator is static and does not model control-loop response.
 - Grid-code, protection, and plant-controller constraints remain project
   inputs.

--- a/models/data/illustrative_capability_curve.csv
+++ b/models/data/illustrative_capability_curve.csv
@@ -1,0 +1,5 @@
+active_mw,reactive_limit_mvar
+0,100
+50,80
+80,50
+100,0

--- a/models/pq_capability.py
+++ b/models/pq_capability.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import argparse
+import csv
 import math
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
+from typing import Sequence
 
 
 class PowerPriority(str, Enum):
@@ -26,8 +29,195 @@ class CapabilityResult:
     priority: PowerPriority
 
 
+@dataclass(frozen=True)
+class CapabilityCurvePoint:
+    active_mw: float
+    reactive_limit_mvar: float
+
+
+@dataclass(frozen=True)
+class PiecewiseCapabilityCurve:
+    """Symmetric positive-quadrant P-Q boundary with linear interpolation."""
+
+    points: tuple[CapabilityCurvePoint, ...]
+
+    def __post_init__(self) -> None:
+        points = tuple(self.points)
+        object.__setattr__(self, "points", points)
+        if len(points) < 2:
+            raise ValueError("capability curve must contain at least two points")
+
+        for index, point in enumerate(points):
+            values = {
+                f"points[{index}].active_mw": point.active_mw,
+                f"points[{index}].reactive_limit_mvar": (point.reactive_limit_mvar),
+            }
+            for name, value in values.items():
+                if not math.isfinite(value):
+                    raise ValueError(f"{name} must be finite")
+                if value < 0.0:
+                    raise ValueError(f"{name} must be nonnegative")
+
+        if points[0].active_mw != 0.0:
+            raise ValueError("capability curve must start on the reactive axis")
+        if points[0].reactive_limit_mvar <= 0.0:
+            raise ValueError("reactive-axis capability must be positive")
+        if points[-1].reactive_limit_mvar != 0.0:
+            raise ValueError("capability curve must end on the active axis")
+        if points[-1].active_mw <= 0.0:
+            raise ValueError("active-axis capability must be positive")
+
+        previous_slope = math.inf
+        for left, right in zip(points[:-1], points[1:], strict=True):
+            active_step = right.active_mw - left.active_mw
+            reactive_step = right.reactive_limit_mvar - left.reactive_limit_mvar
+            if active_step <= 0.0:
+                raise ValueError(
+                    "capability curve active power must be strictly increasing"
+                )
+            if reactive_step >= 0.0:
+                raise ValueError(
+                    "capability curve reactive limit must be strictly decreasing"
+                )
+            slope = reactive_step / active_step
+            if slope > previous_slope + 1e-12:
+                raise ValueError("capability curve must be concave")
+            previous_slope = slope
+
+    @property
+    def maximum_active_mw(self) -> float:
+        return self.points[-1].active_mw
+
+    @property
+    def maximum_reactive_mvar(self) -> float:
+        return self.points[0].reactive_limit_mvar
+
+    def reactive_limit_mvar(self, active_mw: float) -> float:
+        """Interpolate the symmetric reactive limit at signed active power."""
+
+        if not math.isfinite(active_mw):
+            raise ValueError("active_mw must be finite")
+        active_magnitude = abs(active_mw)
+        if active_magnitude >= self.maximum_active_mw:
+            return 0.0
+        for left, right in zip(self.points[:-1], self.points[1:], strict=True):
+            if active_magnitude <= right.active_mw:
+                fraction = (active_magnitude - left.active_mw) / (
+                    right.active_mw - left.active_mw
+                )
+                return left.reactive_limit_mvar + fraction * (
+                    right.reactive_limit_mvar - left.reactive_limit_mvar
+                )
+        raise RuntimeError("validated capability curve did not cover active power")
+
+    def active_limit_mw(self, reactive_mvar: float) -> float:
+        """Interpolate the symmetric active limit at signed reactive power."""
+
+        if not math.isfinite(reactive_mvar):
+            raise ValueError("reactive_mvar must be finite")
+        reactive_magnitude = abs(reactive_mvar)
+        if reactive_magnitude >= self.maximum_reactive_mvar:
+            return 0.0
+        for left, right in zip(self.points[:-1], self.points[1:], strict=True):
+            if reactive_magnitude >= right.reactive_limit_mvar:
+                fraction = (left.reactive_limit_mvar - reactive_magnitude) / (
+                    left.reactive_limit_mvar - right.reactive_limit_mvar
+                )
+                return left.active_mw + fraction * (right.active_mw - left.active_mw)
+        raise RuntimeError("validated capability curve did not cover reactive power")
+
+    def contains(self, active_mw: float, reactive_mvar: float) -> bool:
+        values = {
+            "active_mw": active_mw,
+            "reactive_mvar": reactive_mvar,
+        }
+        for name, value in values.items():
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+        return abs(active_mw) <= self.maximum_active_mw and abs(
+            reactive_mvar
+        ) <= self.reactive_limit_mvar(active_mw)
+
+    def radial_limit_mva(self, active_mw: float, reactive_mvar: float) -> float:
+        """Return the boundary magnitude along the command's P-Q direction."""
+
+        values = {
+            "active_mw": active_mw,
+            "reactive_mvar": reactive_mvar,
+        }
+        for name, value in values.items():
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+        active_magnitude = abs(active_mw)
+        reactive_magnitude = abs(reactive_mvar)
+        if active_magnitude == 0.0:
+            return self.maximum_reactive_mvar
+
+        ray_slope = reactive_magnitude / active_magnitude
+        tolerance = 1e-12 * max(1.0, self.maximum_active_mw)
+        for left, right in zip(self.points[:-1], self.points[1:], strict=True):
+            boundary_slope = (right.reactive_limit_mvar - left.reactive_limit_mvar) / (
+                right.active_mw - left.active_mw
+            )
+            intercept = left.reactive_limit_mvar - boundary_slope * left.active_mw
+            boundary_active_mw = intercept / (ray_slope - boundary_slope)
+            if (
+                left.active_mw - tolerance
+                <= boundary_active_mw
+                <= right.active_mw + tolerance
+            ):
+                boundary_reactive_mvar = ray_slope * boundary_active_mw
+                return math.hypot(
+                    boundary_active_mw,
+                    boundary_reactive_mvar,
+                )
+        raise RuntimeError("validated capability curve did not intersect command ray")
+
+
 def _clip(value: float, limit: float) -> float:
     return max(-limit, min(limit, value))
+
+
+def _select_priority(priority: PowerPriority | str) -> PowerPriority:
+    try:
+        return PowerPriority(priority)
+    except ValueError as error:
+        choices = ", ".join(item.value for item in PowerPriority)
+        raise ValueError(f"priority must be one of: {choices}") from error
+
+
+def _build_result(
+    requested_active_mw: float,
+    requested_reactive_mvar: float,
+    active_mw: float,
+    reactive_mvar: float,
+    utilization: float,
+    priority: PowerPriority,
+) -> CapabilityResult:
+    apparent_power_mva = math.hypot(active_mw, reactive_mvar)
+    active_curtailment = requested_active_mw - active_mw
+    reactive_curtailment = requested_reactive_mvar - reactive_mvar
+    limited = not (
+        math.isclose(active_curtailment, 0.0, rel_tol=0.0, abs_tol=1e-12)
+        and math.isclose(
+            reactive_curtailment,
+            0.0,
+            rel_tol=0.0,
+            abs_tol=1e-12,
+        )
+    )
+    return CapabilityResult(
+        requested_active_mw=requested_active_mw,
+        requested_reactive_mvar=requested_reactive_mvar,
+        active_mw=active_mw,
+        reactive_mvar=reactive_mvar,
+        apparent_power_mva=apparent_power_mva,
+        utilization=utilization,
+        curtailed_active_mw=active_curtailment,
+        curtailed_reactive_mvar=reactive_curtailment,
+        limited=limited,
+        priority=priority,
+    )
 
 
 def allocate_power(
@@ -49,11 +239,7 @@ def allocate_power(
     if apparent_power_limit_mva <= 0.0:
         raise ValueError("apparent_power_limit_mva must be positive")
 
-    try:
-        selected_priority = PowerPriority(priority)
-    except ValueError as error:
-        choices = ", ".join(item.value for item in PowerPriority)
-        raise ValueError(f"priority must be one of: {choices}") from error
+    selected_priority = _select_priority(priority)
 
     requested_mva = math.hypot(
         requested_active_mw,
@@ -64,9 +250,7 @@ def allocate_power(
         reactive_mvar = requested_reactive_mvar
     elif selected_priority is PowerPriority.ACTIVE:
         active_mw = _clip(requested_active_mw, apparent_power_limit_mva)
-        reactive_limit = math.sqrt(
-            max(0.0, apparent_power_limit_mva**2 - active_mw**2)
-        )
+        reactive_limit = math.sqrt(max(0.0, apparent_power_limit_mva**2 - active_mw**2))
         reactive_mvar = _clip(requested_reactive_mvar, reactive_limit)
     elif selected_priority is PowerPriority.REACTIVE:
         reactive_mvar = _clip(
@@ -82,51 +266,153 @@ def allocate_power(
         active_mw = requested_active_mw * scale
         reactive_mvar = requested_reactive_mvar * scale
 
+    return _build_result(
+        requested_active_mw,
+        requested_reactive_mvar,
+        active_mw,
+        reactive_mvar,
+        math.hypot(active_mw, reactive_mvar) / apparent_power_limit_mva,
+        selected_priority,
+    )
+
+
+def allocate_power_on_curve(
+    requested_active_mw: float,
+    requested_reactive_mvar: float,
+    curve: PiecewiseCapabilityCurve,
+    priority: PowerPriority | str = PowerPriority.ACTIVE,
+) -> CapabilityResult:
+    """Apply a sampled symmetric P-Q envelope using the selected priority."""
+
+    values = {
+        "requested_active_mw": requested_active_mw,
+        "requested_reactive_mvar": requested_reactive_mvar,
+    }
+    for name, value in values.items():
+        if not math.isfinite(value):
+            raise ValueError(f"{name} must be finite")
+    selected_priority = _select_priority(priority)
+
+    if curve.contains(requested_active_mw, requested_reactive_mvar):
+        active_mw = requested_active_mw
+        reactive_mvar = requested_reactive_mvar
+    elif selected_priority is PowerPriority.ACTIVE:
+        active_mw = _clip(requested_active_mw, curve.maximum_active_mw)
+        reactive_mvar = _clip(
+            requested_reactive_mvar,
+            curve.reactive_limit_mvar(active_mw),
+        )
+    elif selected_priority is PowerPriority.REACTIVE:
+        reactive_mvar = _clip(
+            requested_reactive_mvar,
+            curve.maximum_reactive_mvar,
+        )
+        active_mw = _clip(
+            requested_active_mw,
+            curve.active_limit_mw(reactive_mvar),
+        )
+    else:
+        requested_mva = math.hypot(
+            requested_active_mw,
+            requested_reactive_mvar,
+        )
+        scale = (
+            curve.radial_limit_mva(
+                requested_active_mw,
+                requested_reactive_mvar,
+            )
+            / requested_mva
+        )
+        active_mw = requested_active_mw * scale
+        reactive_mvar = requested_reactive_mvar * scale
+
     apparent_power_mva = math.hypot(active_mw, reactive_mvar)
-    active_curtailment = requested_active_mw - active_mw
-    reactive_curtailment = requested_reactive_mvar - reactive_mvar
-    limited = not (
-        math.isclose(active_curtailment, 0.0, rel_tol=0.0, abs_tol=1e-12)
-        and math.isclose(reactive_curtailment, 0.0, rel_tol=0.0, abs_tol=1e-12)
-    )
-
-    return CapabilityResult(
-        requested_active_mw=requested_active_mw,
-        requested_reactive_mvar=requested_reactive_mvar,
-        active_mw=active_mw,
-        reactive_mvar=reactive_mvar,
-        apparent_power_mva=apparent_power_mva,
-        utilization=apparent_power_mva / apparent_power_limit_mva,
-        curtailed_active_mw=active_curtailment,
-        curtailed_reactive_mvar=reactive_curtailment,
-        limited=limited,
-        priority=selected_priority,
+    utilization = 0.0
+    if apparent_power_mva > 0.0:
+        utilization = min(
+            1.0,
+            apparent_power_mva / curve.radial_limit_mva(active_mw, reactive_mvar),
+        )
+    return _build_result(
+        requested_active_mw,
+        requested_reactive_mvar,
+        active_mw,
+        reactive_mvar,
+        utilization,
+        selected_priority,
     )
 
 
-def parse_args() -> argparse.Namespace:
+def load_capability_curve_csv(path: str | Path) -> PiecewiseCapabilityCurve:
+    """Load a strict active/reactive-limit capability curve from CSV."""
+
+    csv_path = Path(path)
+    with csv_path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        expected_columns = ("active_mw", "reactive_limit_mvar")
+        if tuple(reader.fieldnames or ()) != expected_columns:
+            raise ValueError(
+                "capability curve CSV header must be active_mw,reactive_limit_mvar"
+            )
+        points: list[CapabilityCurvePoint] = []
+        for line_number, row in enumerate(reader, start=2):
+            if None in row or any(
+                value is None or not value.strip() for value in row.values()
+            ):
+                raise ValueError(
+                    f"capability curve CSV line {line_number} must be complete"
+                )
+            try:
+                point = CapabilityCurvePoint(
+                    active_mw=float(row["active_mw"]),
+                    reactive_limit_mvar=float(row["reactive_limit_mvar"]),
+                )
+            except ValueError as error:
+                raise ValueError(
+                    f"capability curve CSV line {line_number} must be numeric"
+                ) from error
+            points.append(point)
+    return PiecewiseCapabilityCurve(tuple(points))
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Apply a circular inverter P-Q capability limit."
+        description="Apply a circular or sampled inverter P-Q capability limit."
     )
     parser.add_argument("--active-mw", type=float, required=True)
     parser.add_argument("--reactive-mvar", type=float, required=True)
-    parser.add_argument("--limit-mva", type=float, required=True)
+    boundary = parser.add_mutually_exclusive_group(required=True)
+    boundary.add_argument("--limit-mva", type=float)
+    boundary.add_argument("--curve-csv", type=Path)
     parser.add_argument(
         "--priority",
         choices=[item.value for item in PowerPriority],
         default=PowerPriority.ACTIVE.value,
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
-def main() -> int:
-    args = parse_args()
-    result = allocate_power(
-        args.active_mw,
-        args.reactive_mvar,
-        args.limit_mva,
-        args.priority,
-    )
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.curve_csv is None:
+        result = allocate_power(
+            args.active_mw,
+            args.reactive_mvar,
+            args.limit_mva,
+            args.priority,
+        )
+        capability_model = None
+    else:
+        curve = load_capability_curve_csv(args.curve_csv)
+        result = allocate_power_on_curve(
+            args.active_mw,
+            args.reactive_mvar,
+            curve,
+            args.priority,
+        )
+        capability_model = f"piecewise curve ({len(curve.points)} points)"
+    if capability_model is not None:
+        print(f"Capability model: {capability_model}")
     print(f"Priority: {result.priority.value}")
     print(f"Limited: {str(result.limited).lower()}")
     print(f"Active power: {result.active_mw:.3f} MW")
@@ -134,10 +420,7 @@ def main() -> int:
     print(f"Apparent power: {result.apparent_power_mva:.3f} MVA")
     print(f"Capability utilization: {100.0 * result.utilization:.2f}%")
     print(f"Active curtailment: {result.curtailed_active_mw:.3f} MW")
-    print(
-        "Reactive curtailment: "
-        f"{result.curtailed_reactive_mvar:.3f} MVAr"
-    )
+    print(f"Reactive curtailment: {result.curtailed_reactive_mvar:.3f} MVAr")
     return 0
 
 

--- a/tests/test_pq_capability.py
+++ b/tests/test_pq_capability.py
@@ -1,12 +1,34 @@
 from __future__ import annotations
 
+import contextlib
+import io
 import math
+import tempfile
 import unittest
+from pathlib import Path
 
-from models.pq_capability import PowerPriority, allocate_power
+from models.pq_capability import (
+    CapabilityCurvePoint,
+    PiecewiseCapabilityCurve,
+    PowerPriority,
+    allocate_power,
+    allocate_power_on_curve,
+    load_capability_curve_csv,
+    main,
+)
 
 
 class PqCapabilityTests(unittest.TestCase):
+    def setUp(self):
+        self.curve = PiecewiseCapabilityCurve(
+            (
+                CapabilityCurvePoint(0.0, 100.0),
+                CapabilityCurvePoint(50.0, 80.0),
+                CapabilityCurvePoint(80.0, 50.0),
+                CapabilityCurvePoint(100.0, 0.0),
+            )
+        )
+
     def test_feasible_request_passes_through(self):
         result = allocate_power(60.0, 40.0, 100.0)
         self.assertEqual(result.active_mw, 60.0)
@@ -53,6 +75,207 @@ class PqCapabilityTests(unittest.TestCase):
             allocate_power(math.nan, 10.0, 100.0)
         with self.assertRaisesRegex(ValueError, "priority must be one of"):
             allocate_power(10.0, 10.0, 100.0, "unknown")
+
+    def test_piecewise_rejects_invalid_inputs(self):
+        with self.assertRaisesRegex(ValueError, "must be finite"):
+            allocate_power_on_curve(math.nan, 10.0, self.curve)
+        with self.assertRaisesRegex(ValueError, "priority must be one of"):
+            allocate_power_on_curve(10.0, 10.0, self.curve, "unknown")
+        with self.assertRaisesRegex(ValueError, "must be finite"):
+            self.curve.reactive_limit_mvar(math.inf)
+
+    def test_piecewise_curve_interpolates_both_axes(self):
+        self.assertAlmostEqual(self.curve.reactive_limit_mvar(65.0), 65.0)
+        self.assertAlmostEqual(self.curve.reactive_limit_mvar(-65.0), 65.0)
+        self.assertAlmostEqual(self.curve.active_limit_mw(65.0), 65.0)
+        self.assertAlmostEqual(self.curve.active_limit_mw(-65.0), 65.0)
+        self.assertAlmostEqual(self.curve.reactive_limit_mvar(120.0), 0.0)
+        self.assertAlmostEqual(self.curve.active_limit_mw(120.0), 0.0)
+
+    def test_piecewise_curve_rejects_invalid_shapes(self):
+        invalid_curves = (
+            (
+                (CapabilityCurvePoint(0.0, 100.0),),
+                "at least two points",
+            ),
+            (
+                (
+                    CapabilityCurvePoint(1.0, 100.0),
+                    CapabilityCurvePoint(100.0, 0.0),
+                ),
+                "reactive axis",
+            ),
+            (
+                (
+                    CapabilityCurvePoint(0.0, 100.0),
+                    CapabilityCurvePoint(100.0, 1.0),
+                ),
+                "active axis",
+            ),
+            (
+                (
+                    CapabilityCurvePoint(0.0, 100.0),
+                    CapabilityCurvePoint(50.0, 60.0),
+                    CapabilityCurvePoint(40.0, 0.0),
+                ),
+                "strictly increasing",
+            ),
+            (
+                (
+                    CapabilityCurvePoint(0.0, 100.0),
+                    CapabilityCurvePoint(50.0, 20.0),
+                    CapabilityCurvePoint(100.0, 0.0),
+                ),
+                "concave",
+            ),
+            (
+                (
+                    CapabilityCurvePoint(0.0, math.inf),
+                    CapabilityCurvePoint(100.0, 0.0),
+                ),
+                "must be finite",
+            ),
+        )
+        for points, message in invalid_curves:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    PiecewiseCapabilityCurve(points)
+
+    def test_piecewise_feasible_request_passes_through(self):
+        result = allocate_power_on_curve(40.0, 60.0, self.curve)
+        self.assertEqual(result.active_mw, 40.0)
+        self.assertEqual(result.reactive_mvar, 60.0)
+        self.assertFalse(result.limited)
+        self.assertLess(result.utilization, 1.0)
+
+    def test_piecewise_active_priority_preserves_active_command(self):
+        result = allocate_power_on_curve(
+            80.0,
+            80.0,
+            self.curve,
+            PowerPriority.ACTIVE,
+        )
+        self.assertAlmostEqual(result.active_mw, 80.0)
+        self.assertAlmostEqual(result.reactive_mvar, 50.0)
+        self.assertAlmostEqual(result.utilization, 1.0)
+
+    def test_piecewise_reactive_priority_preserves_reactive_command(self):
+        result = allocate_power_on_curve(
+            80.0,
+            80.0,
+            self.curve,
+            PowerPriority.REACTIVE,
+        )
+        self.assertAlmostEqual(result.active_mw, 50.0)
+        self.assertAlmostEqual(result.reactive_mvar, 80.0)
+        self.assertAlmostEqual(result.utilization, 1.0)
+
+    def test_piecewise_proportional_priority_preserves_ratio(self):
+        result = allocate_power_on_curve(
+            80.0,
+            80.0,
+            self.curve,
+            PowerPriority.PROPORTIONAL,
+        )
+        self.assertAlmostEqual(result.active_mw, 65.0)
+        self.assertAlmostEqual(result.reactive_mvar, 65.0)
+        self.assertAlmostEqual(result.active_mw / result.reactive_mvar, 1.0)
+        self.assertAlmostEqual(result.utilization, 1.0)
+
+    def test_piecewise_allocation_preserves_negative_quadrant(self):
+        result = allocate_power_on_curve(
+            -80.0,
+            -80.0,
+            self.curve,
+            PowerPriority.ACTIVE,
+        )
+        self.assertAlmostEqual(result.active_mw, -80.0)
+        self.assertAlmostEqual(result.reactive_mvar, -50.0)
+        self.assertLess(result.curtailed_reactive_mvar, 0.0)
+
+    def test_piecewise_single_axis_requests_reach_axis_limits(self):
+        active = allocate_power_on_curve(
+            120.0,
+            10.0,
+            self.curve,
+            PowerPriority.ACTIVE,
+        )
+        reactive = allocate_power_on_curve(
+            10.0,
+            120.0,
+            self.curve,
+            PowerPriority.REACTIVE,
+        )
+        self.assertAlmostEqual(active.active_mw, 100.0)
+        self.assertAlmostEqual(active.reactive_mvar, 0.0)
+        self.assertAlmostEqual(reactive.active_mw, 0.0)
+        self.assertAlmostEqual(reactive.reactive_mvar, 100.0)
+
+    def test_loads_strict_piecewise_curve_csv(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            path = Path(temporary_directory) / "curve.csv"
+            path.write_text(
+                "active_mw,reactive_limit_mvar\n0,100\n50,80\n80,50\n100,0\n",
+                encoding="utf-8",
+            )
+            loaded = load_capability_curve_csv(path)
+        self.assertEqual(loaded, self.curve)
+
+    def test_curve_csv_rejects_wrong_header_and_incomplete_rows(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            path = Path(temporary_directory) / "curve.csv"
+            path.write_text("p,q\n0,100\n100,0\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "CSV header"):
+                load_capability_curve_csv(path)
+            path.write_text(
+                "active_mw,reactive_limit_mvar\n0,100\n100,\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "must be complete"):
+                load_capability_curve_csv(path)
+
+    def test_cli_runs_committed_piecewise_curve(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--active-mw",
+                    "80",
+                    "--reactive-mvar",
+                    "80",
+                    "--curve-csv",
+                    "models/data/illustrative_capability_curve.csv",
+                    "--priority",
+                    "active",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Capability model: piecewise curve (4 points)", output)
+        self.assertIn("Active power: 80.000 MW", output)
+        self.assertIn("Reactive power: 50.000 MVAr", output)
+        self.assertIn("Capability utilization: 100.00%", output)
+
+    def test_legacy_circular_cli_output_stays_compatible(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--active-mw",
+                    "80",
+                    "--reactive-mvar",
+                    "80",
+                    "--limit-mva",
+                    "100",
+                    "--priority",
+                    "active",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertTrue(output.startswith("Priority: active\n"))
+        self.assertNotIn("Capability model:", output)
+        self.assertIn("Reactive power: 60.000 MVAr", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add a strict CSV loader for a quadrant-symmetric piecewise P-Q capability envelope
- preserve active, reactive, and proportional priority behavior with exact linear interpolation
- validate axis endpoints, monotonicity, concavity, finite values, and complete CSV rows
- retain the circular allocator and its CLI output as the backward-compatible default
- run the committed noncircular envelope in CI and document scope and limitations

## Why

The executable reference explicitly identified its fixed circular capability boundary as a limitation. Real studies often begin with sampled operating-envelope points, so this adds a traceable opt-in path without embedding an unsupported OEM curve or silently changing the existing service models.

## Validation

- `python -m unittest discover -s tests -v` (86 tests)
- committed 80 MW / 80 MVAr curve example delivers 80 MW / 50 MVAr at 100% boundary utilization
- legacy 80 MW / 80 MVAr circular example remains 80 MW / 60 MVAr with unchanged CLI output
- independent 10,000-envelope oracle covering 30,000 priority allocations: maximum component discrepancy `2.842e-14`, maximum envelope excess `3.944e-13`, zero utilization-bound excess
- Python compilation, Ruff checks and formatting, workflow Prettier, Markdown lint, CSV schema validation, and `git diff --check`