### PR TITLE
Add directional P-Q capability envelopes

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -42,6 +42,14 @@ jobs:
           --curve-csv models/data/illustrative_capability_curve.csv
           --priority active
 
+      - name: Run directional capability envelope
+        run: >-
+          python models/pq_capability.py
+          --active-mw -65 --reactive-mvar -70
+          --directional-curve-csv
+          models/data/illustrative_directional_capability.csv
+          --priority active
+
       - name: Check Markdown links
         uses: lycheeverse/lychee-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ LICENSE
 ## Run The Executable Reference
 
 The dependency-free allocator demonstrates active-priority, reactive-priority,
-and proportional handling of commands outside a circular MVA limit or sampled
-piecewise P-Q envelope:
+and proportional handling of commands outside a circular MVA limit, symmetric
+sampled curve, or directional four-quadrant P-Q envelope:
 
 ```powershell
 python models/pq_capability.py `
@@ -106,6 +106,10 @@ python models/pq_capability.py `
 python models/pq_capability.py `
   --active-mw 80 --reactive-mvar 80 `
   --curve-csv models/data/illustrative_capability_curve.csv --priority active
+python models/pq_capability.py `
+  --active-mw -65 --reactive-mvar -70 `
+  --directional-curve-csv `
+    models/data/illustrative_directional_capability.csv --priority active
 python models/volt_var.py `
   --voltage-pu 0.95 --active-mw 90 --limit-mva 100
 python models/frequency_watt.py `

--- a/models/README.md
+++ b/models/README.md
@@ -22,10 +22,12 @@ follows:
   active power; or
 - `proportional`: scale active and reactive power by the same factor.
 
-The optional CSV envelope samples the positive-quadrant boundary as strictly
+The symmetric CSV envelope samples the positive-quadrant boundary as strictly
 increasing active power and strictly decreasing reactive limit. The loader
 requires reactive-axis and active-axis endpoints plus a concave piecewise-linear
-shape. Allocation mirrors that boundary into all four quadrants.
+shape. Allocation mirrors that boundary into all four quadrants. A directional
+CSV may instead provide separate discharge/injection, discharge/absorption,
+charge/injection, and charge/absorption curves.
 
 ## Run A Constrained Example
 
@@ -65,6 +67,53 @@ Reactive power: 50.000 MVAr
 Capability utilization: 100.00%
 ```
 
+## Directional Four-Quadrant Envelope
+
+Use `--directional-curve-csv` when charge and discharge capability or reactive
+injection and absorption capability differ. The strict CSV groups four curves
+by these exact quadrant identifiers:
+
+- `discharge_injection`
+- `discharge_absorption`
+- `charge_injection`
+- `charge_absorption`
+
+Each group uses nonnegative magnitudes and follows the same increasing-active,
+decreasing-reactive, concave shape contract as the symmetric curve. Curves on
+either side of an axis must share that axis intercept: both discharge curves
+must have the same active limit, both charge curves must have the same active
+limit, and the corresponding charge/discharge curves must agree on injection
+or absorption limits at zero active power. This makes commands on an axis
+independent of an arbitrary quadrant choice.
+
+Run the committed charge-and-absorption example:
+
+```powershell
+python models/pq_capability.py `
+  --active-mw -65 `
+  --reactive-mvar -70 `
+  --directional-curve-csv `
+    models/data/illustrative_directional_capability.csv `
+  --priority active
+```
+
+Expected key values:
+
+```text
+Capability model: directional envelope (4 quadrants, 16 points)
+Capability quadrant: charge_absorption
+Active power: -65.000 MW
+Reactive power: -40.000 MVAr
+Capability utilization: 100.00%
+```
+
+The example deliberately limits charging to 80 MW, discharge to 100 MW,
+reactive injection to 100 MVAr, and absorption to 90 MVAr, with different
+interior boundaries in every quadrant. These are illustrative values, not a
+claim about a particular PCS. The Python API exposes
+`DirectionalCapabilityEnvelope`, `load_directional_capability_csv`, and
+`allocate_power_on_directional_envelope` for the same operation.
+
 Run the regression checks with:
 
 ```powershell
@@ -73,9 +122,9 @@ python -m unittest discover -s tests -v
 
 ## Explicit Limitations
 
-- The sampled curve is quadrant-symmetric, concave, and linearly interpolated.
-  Use separate project logic for asymmetric charge/discharge or reactive
-  injection/absorption limits.
+- Every sampled quadrant curve is concave and linearly interpolated. The
+  symmetric input mirrors one curve; the directional input requires four
+  curves and consistent shared-axis intercepts.
 - Dynamic current limits, voltage dependence, and temperature derating are
   not calculated internally. They can be represented only after an external
   study supplies the applicable sampled envelope. SOC and interval-duration

--- a/models/data/illustrative_directional_capability.csv
+++ b/models/data/illustrative_directional_capability.csv
@@ -1,0 +1,17 @@
+quadrant,active_mw,reactive_limit_mvar
+discharge_injection,0,100
+discharge_injection,50,85
+discharge_injection,80,55
+discharge_injection,100,0
+discharge_absorption,0,90
+discharge_absorption,50,75
+discharge_absorption,80,45
+discharge_absorption,100,0
+charge_injection,0,100
+charge_injection,40,82
+charge_injection,65,50
+charge_injection,80,0
+charge_absorption,0,90
+charge_absorption,40,70
+charge_absorption,65,40
+charge_absorption,80,0

--- a/models/pq_capability.py
+++ b/models/pq_capability.py
@@ -15,6 +15,13 @@ class PowerPriority(str, Enum):
     PROPORTIONAL = "proportional"
 
 
+class CapabilityQuadrant(str, Enum):
+    DISCHARGE_INJECTION = "discharge_injection"
+    DISCHARGE_ABSORPTION = "discharge_absorption"
+    CHARGE_INJECTION = "charge_injection"
+    CHARGE_ABSORPTION = "charge_absorption"
+
+
 @dataclass(frozen=True)
 class CapabilityResult:
     requested_active_mw: float
@@ -172,6 +179,85 @@ class PiecewiseCapabilityCurve:
                     boundary_reactive_mvar,
                 )
         raise RuntimeError("validated capability curve did not intersect command ray")
+
+
+@dataclass(frozen=True)
+class DirectionalCapabilityEnvelope:
+    """Four signed P-Q boundaries with consistent shared-axis limits."""
+
+    discharge_injection: PiecewiseCapabilityCurve
+    discharge_absorption: PiecewiseCapabilityCurve
+    charge_injection: PiecewiseCapabilityCurve
+    charge_absorption: PiecewiseCapabilityCurve
+
+    def __post_init__(self) -> None:
+        curves = self.curves
+        for quadrant, curve in curves.items():
+            if not isinstance(curve, PiecewiseCapabilityCurve):
+                raise ValueError(f"{quadrant.value} must be a PiecewiseCapabilityCurve")
+
+        self._require_shared_axis(
+            "discharge active-axis",
+            self.discharge_injection.maximum_active_mw,
+            self.discharge_absorption.maximum_active_mw,
+        )
+        self._require_shared_axis(
+            "charge active-axis",
+            self.charge_injection.maximum_active_mw,
+            self.charge_absorption.maximum_active_mw,
+        )
+        self._require_shared_axis(
+            "injection reactive-axis",
+            self.discharge_injection.maximum_reactive_mvar,
+            self.charge_injection.maximum_reactive_mvar,
+        )
+        self._require_shared_axis(
+            "absorption reactive-axis",
+            self.discharge_absorption.maximum_reactive_mvar,
+            self.charge_absorption.maximum_reactive_mvar,
+        )
+
+    @staticmethod
+    def _require_shared_axis(name: str, first: float, second: float) -> None:
+        if not math.isclose(first, second, rel_tol=1e-12, abs_tol=1e-12):
+            raise ValueError(f"directional envelope {name} limits must match")
+
+    @property
+    def curves(self) -> dict[CapabilityQuadrant, PiecewiseCapabilityCurve]:
+        return {
+            CapabilityQuadrant.DISCHARGE_INJECTION: self.discharge_injection,
+            CapabilityQuadrant.DISCHARGE_ABSORPTION: self.discharge_absorption,
+            CapabilityQuadrant.CHARGE_INJECTION: self.charge_injection,
+            CapabilityQuadrant.CHARGE_ABSORPTION: self.charge_absorption,
+        }
+
+    @property
+    def point_count(self) -> int:
+        return sum(len(curve.points) for curve in self.curves.values())
+
+    def quadrant_for(
+        self,
+        active_mw: float,
+        reactive_mvar: float,
+    ) -> CapabilityQuadrant:
+        values = {"active_mw": active_mw, "reactive_mvar": reactive_mvar}
+        for name, value in values.items():
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+        if active_mw >= 0.0:
+            if reactive_mvar >= 0.0:
+                return CapabilityQuadrant.DISCHARGE_INJECTION
+            return CapabilityQuadrant.DISCHARGE_ABSORPTION
+        if reactive_mvar >= 0.0:
+            return CapabilityQuadrant.CHARGE_INJECTION
+        return CapabilityQuadrant.CHARGE_ABSORPTION
+
+    def curve_for(
+        self,
+        active_mw: float,
+        reactive_mvar: float,
+    ) -> PiecewiseCapabilityCurve:
+        return self.curves[self.quadrant_for(active_mw, reactive_mvar)]
 
 
 def _clip(value: float, limit: float) -> float:
@@ -343,6 +429,23 @@ def allocate_power_on_curve(
     )
 
 
+def allocate_power_on_directional_envelope(
+    requested_active_mw: float,
+    requested_reactive_mvar: float,
+    envelope: DirectionalCapabilityEnvelope,
+    priority: PowerPriority | str = PowerPriority.ACTIVE,
+) -> CapabilityResult:
+    """Apply the sampled boundary for the requested command quadrant."""
+
+    curve = envelope.curve_for(requested_active_mw, requested_reactive_mvar)
+    return allocate_power_on_curve(
+        requested_active_mw,
+        requested_reactive_mvar,
+        curve,
+        priority,
+    )
+
+
 def load_capability_curve_csv(path: str | Path) -> PiecewiseCapabilityCurve:
     """Load a strict active/reactive-limit capability curve from CSV."""
 
@@ -375,15 +478,82 @@ def load_capability_curve_csv(path: str | Path) -> PiecewiseCapabilityCurve:
     return PiecewiseCapabilityCurve(tuple(points))
 
 
+def load_directional_capability_csv(
+    path: str | Path,
+) -> DirectionalCapabilityEnvelope:
+    """Load four strict quadrant-specific capability curves from one CSV."""
+
+    csv_path = Path(path)
+    grouped_points: dict[CapabilityQuadrant, list[CapabilityCurvePoint]] = {
+        quadrant: [] for quadrant in CapabilityQuadrant
+    }
+    with csv_path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        expected_columns = (
+            "quadrant",
+            "active_mw",
+            "reactive_limit_mvar",
+        )
+        if tuple(reader.fieldnames or ()) != expected_columns:
+            raise ValueError(
+                "directional capability CSV header must be "
+                "quadrant,active_mw,reactive_limit_mvar"
+            )
+        for line_number, row in enumerate(reader, start=2):
+            if None in row or any(
+                value is None or not value.strip() for value in row.values()
+            ):
+                raise ValueError(
+                    f"directional capability CSV line {line_number} must be complete"
+                )
+            try:
+                quadrant = CapabilityQuadrant(row["quadrant"])
+            except ValueError as error:
+                choices = ", ".join(item.value for item in CapabilityQuadrant)
+                raise ValueError(
+                    f"directional capability CSV line {line_number} quadrant "
+                    f"must be one of: {choices}"
+                ) from error
+            try:
+                point = CapabilityCurvePoint(
+                    active_mw=float(row["active_mw"]),
+                    reactive_limit_mvar=float(row["reactive_limit_mvar"]),
+                )
+            except ValueError as error:
+                raise ValueError(
+                    f"directional capability CSV line {line_number} must be numeric"
+                ) from error
+            grouped_points[quadrant].append(point)
+
+    curves: dict[CapabilityQuadrant, PiecewiseCapabilityCurve] = {}
+    for quadrant, points in grouped_points.items():
+        if not points:
+            raise ValueError(
+                f"directional capability CSV is missing {quadrant.value} points"
+            )
+        try:
+            curves[quadrant] = PiecewiseCapabilityCurve(tuple(points))
+        except ValueError as error:
+            raise ValueError(f"invalid {quadrant.value} curve: {error}") from error
+
+    return DirectionalCapabilityEnvelope(
+        discharge_injection=curves[CapabilityQuadrant.DISCHARGE_INJECTION],
+        discharge_absorption=curves[CapabilityQuadrant.DISCHARGE_ABSORPTION],
+        charge_injection=curves[CapabilityQuadrant.CHARGE_INJECTION],
+        charge_absorption=curves[CapabilityQuadrant.CHARGE_ABSORPTION],
+    )
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Apply a circular or sampled inverter P-Q capability limit."
+        description="Apply a circular, symmetric, or directional P-Q limit."
     )
     parser.add_argument("--active-mw", type=float, required=True)
     parser.add_argument("--reactive-mvar", type=float, required=True)
     boundary = parser.add_mutually_exclusive_group(required=True)
     boundary.add_argument("--limit-mva", type=float)
     boundary.add_argument("--curve-csv", type=Path)
+    boundary.add_argument("--directional-curve-csv", type=Path)
     parser.add_argument(
         "--priority",
         choices=[item.value for item in PowerPriority],
@@ -394,7 +564,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
-    if args.curve_csv is None:
+    selected_quadrant = None
+    if args.limit_mva is not None:
         result = allocate_power(
             args.active_mw,
             args.reactive_mvar,
@@ -402,7 +573,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             args.priority,
         )
         capability_model = None
-    else:
+    elif args.curve_csv is not None:
         curve = load_capability_curve_csv(args.curve_csv)
         result = allocate_power_on_curve(
             args.active_mw,
@@ -411,8 +582,25 @@ def main(argv: Sequence[str] | None = None) -> int:
             args.priority,
         )
         capability_model = f"piecewise curve ({len(curve.points)} points)"
+    else:
+        envelope = load_directional_capability_csv(args.directional_curve_csv)
+        result = allocate_power_on_directional_envelope(
+            args.active_mw,
+            args.reactive_mvar,
+            envelope,
+            args.priority,
+        )
+        selected_quadrant = envelope.quadrant_for(
+            args.active_mw,
+            args.reactive_mvar,
+        )
+        capability_model = (
+            f"directional envelope (4 quadrants, {envelope.point_count} points)"
+        )
     if capability_model is not None:
         print(f"Capability model: {capability_model}")
+    if selected_quadrant is not None:
+        print(f"Capability quadrant: {selected_quadrant.value}")
     print(f"Priority: {result.priority.value}")
     print(f"Limited: {str(result.limited).lower()}")
     print(f"Active power: {result.active_mw:.3f} MW")

--- a/tests/test_pq_capability.py
+++ b/tests/test_pq_capability.py
@@ -8,12 +8,16 @@ import unittest
 from pathlib import Path
 
 from models.pq_capability import (
+    CapabilityQuadrant,
     CapabilityCurvePoint,
+    DirectionalCapabilityEnvelope,
     PiecewiseCapabilityCurve,
     PowerPriority,
     allocate_power,
+    allocate_power_on_directional_envelope,
     allocate_power_on_curve,
     load_capability_curve_csv,
+    load_directional_capability_csv,
     main,
 )
 
@@ -27,6 +31,40 @@ class PqCapabilityTests(unittest.TestCase):
                 CapabilityCurvePoint(80.0, 50.0),
                 CapabilityCurvePoint(100.0, 0.0),
             )
+        )
+        self.envelope = DirectionalCapabilityEnvelope(
+            discharge_injection=PiecewiseCapabilityCurve(
+                (
+                    CapabilityCurvePoint(0.0, 100.0),
+                    CapabilityCurvePoint(50.0, 85.0),
+                    CapabilityCurvePoint(80.0, 55.0),
+                    CapabilityCurvePoint(100.0, 0.0),
+                )
+            ),
+            discharge_absorption=PiecewiseCapabilityCurve(
+                (
+                    CapabilityCurvePoint(0.0, 90.0),
+                    CapabilityCurvePoint(50.0, 75.0),
+                    CapabilityCurvePoint(80.0, 45.0),
+                    CapabilityCurvePoint(100.0, 0.0),
+                )
+            ),
+            charge_injection=PiecewiseCapabilityCurve(
+                (
+                    CapabilityCurvePoint(0.0, 100.0),
+                    CapabilityCurvePoint(40.0, 82.0),
+                    CapabilityCurvePoint(65.0, 50.0),
+                    CapabilityCurvePoint(80.0, 0.0),
+                )
+            ),
+            charge_absorption=PiecewiseCapabilityCurve(
+                (
+                    CapabilityCurvePoint(0.0, 90.0),
+                    CapabilityCurvePoint(40.0, 70.0),
+                    CapabilityCurvePoint(65.0, 40.0),
+                    CapabilityCurvePoint(80.0, 0.0),
+                )
+            ),
         )
 
     def test_feasible_request_passes_through(self):
@@ -211,6 +249,86 @@ class PqCapabilityTests(unittest.TestCase):
         self.assertAlmostEqual(reactive.active_mw, 0.0)
         self.assertAlmostEqual(reactive.reactive_mvar, 100.0)
 
+    def test_directional_envelope_selects_all_four_quadrants(self):
+        cases = (
+            (10.0, 10.0, CapabilityQuadrant.DISCHARGE_INJECTION),
+            (10.0, -10.0, CapabilityQuadrant.DISCHARGE_ABSORPTION),
+            (-10.0, 10.0, CapabilityQuadrant.CHARGE_INJECTION),
+            (-10.0, -10.0, CapabilityQuadrant.CHARGE_ABSORPTION),
+        )
+        for active_mw, reactive_mvar, expected in cases:
+            with self.subTest(quadrant=expected.value):
+                self.assertEqual(
+                    self.envelope.quadrant_for(active_mw, reactive_mvar),
+                    expected,
+                )
+        self.assertEqual(self.envelope.point_count, 16)
+
+    def test_directional_active_priority_uses_charge_absorption_curve(self):
+        result = allocate_power_on_directional_envelope(
+            -65.0,
+            -70.0,
+            self.envelope,
+            PowerPriority.ACTIVE,
+        )
+        self.assertAlmostEqual(result.active_mw, -65.0)
+        self.assertAlmostEqual(result.reactive_mvar, -40.0)
+        self.assertAlmostEqual(result.utilization, 1.0)
+
+    def test_directional_reactive_priority_uses_charge_absorption_curve(self):
+        result = allocate_power_on_directional_envelope(
+            -65.0,
+            -70.0,
+            self.envelope,
+            PowerPriority.REACTIVE,
+        )
+        self.assertAlmostEqual(result.active_mw, -40.0)
+        self.assertAlmostEqual(result.reactive_mvar, -70.0)
+        self.assertAlmostEqual(result.utilization, 1.0)
+
+    def test_directional_proportional_priority_preserves_quadrant_and_ratio(self):
+        result = allocate_power_on_directional_envelope(
+            -80.0,
+            80.0,
+            self.envelope,
+            PowerPriority.PROPORTIONAL,
+        )
+        selected_curve = self.envelope.charge_injection
+        self.assertTrue(selected_curve.contains(result.active_mw, result.reactive_mvar))
+        self.assertLess(result.active_mw, 0.0)
+        self.assertGreater(result.reactive_mvar, 0.0)
+        self.assertAlmostEqual(result.active_mw / result.reactive_mvar, -1.0)
+        self.assertAlmostEqual(result.utilization, 1.0)
+
+    def test_directional_envelope_requires_shared_axis_limits(self):
+        mismatched_active_axis = PiecewiseCapabilityCurve(
+            (
+                CapabilityCurvePoint(0.0, 90.0),
+                CapabilityCurvePoint(110.0, 0.0),
+            )
+        )
+        with self.assertRaisesRegex(ValueError, "discharge active-axis"):
+            DirectionalCapabilityEnvelope(
+                discharge_injection=self.envelope.discharge_injection,
+                discharge_absorption=mismatched_active_axis,
+                charge_injection=self.envelope.charge_injection,
+                charge_absorption=self.envelope.charge_absorption,
+            )
+
+        mismatched_reactive_axis = PiecewiseCapabilityCurve(
+            (
+                CapabilityCurvePoint(0.0, 110.0),
+                CapabilityCurvePoint(80.0, 0.0),
+            )
+        )
+        with self.assertRaisesRegex(ValueError, "injection reactive-axis"):
+            DirectionalCapabilityEnvelope(
+                discharge_injection=self.envelope.discharge_injection,
+                discharge_absorption=self.envelope.discharge_absorption,
+                charge_injection=mismatched_reactive_axis,
+                charge_absorption=self.envelope.charge_absorption,
+            )
+
     def test_loads_strict_piecewise_curve_csv(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             path = Path(temporary_directory) / "curve.csv"
@@ -220,6 +338,32 @@ class PqCapabilityTests(unittest.TestCase):
             )
             loaded = load_capability_curve_csv(path)
         self.assertEqual(loaded, self.curve)
+
+    def test_loads_committed_directional_capability_csv(self):
+        loaded = load_directional_capability_csv(
+            "models/data/illustrative_directional_capability.csv"
+        )
+        self.assertEqual(loaded, self.envelope)
+
+    def test_directional_csv_rejects_unknown_and_missing_quadrants(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            path = Path(temporary_directory) / "directional.csv"
+            path.write_text(
+                "quadrant,active_mw,reactive_limit_mvar\n"
+                "unknown,0,100\nunknown,100,0\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "quadrant must be one of"):
+                load_directional_capability_csv(path)
+
+            path.write_text(
+                "quadrant,active_mw,reactive_limit_mvar\n"
+                "discharge_injection,0,100\n"
+                "discharge_injection,100,0\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "missing discharge_absorption"):
+                load_directional_capability_csv(path)
 
     def test_curve_csv_rejects_wrong_header_and_incomplete_rows(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -254,6 +398,32 @@ class PqCapabilityTests(unittest.TestCase):
         self.assertIn("Capability model: piecewise curve (4 points)", output)
         self.assertIn("Active power: 80.000 MW", output)
         self.assertIn("Reactive power: 50.000 MVAr", output)
+        self.assertIn("Capability utilization: 100.00%", output)
+
+    def test_cli_runs_committed_directional_envelope(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--active-mw",
+                    "-65",
+                    "--reactive-mvar",
+                    "-70",
+                    "--directional-curve-csv",
+                    "models/data/illustrative_directional_capability.csv",
+                    "--priority",
+                    "active",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn(
+            "Capability model: directional envelope (4 quadrants, 16 points)",
+            output,
+        )
+        self.assertIn("Capability quadrant: charge_absorption", output)
+        self.assertIn("Active power: -65.000 MW", output)
+        self.assertIn("Reactive power: -40.000 MVAr", output)
         self.assertIn("Capability utilization: 100.00%", output)
 
     def test_legacy_circular_cli_output_stays_compatible(self):


### PR DESCRIPTION
## Summary

- add strict four-quadrant sampled capability envelopes for asymmetric charge/discharge and reactive injection/absorption limits
- require shared axis intercepts, select the boundary by command sign, and preserve active, reactive, and proportional priority behavior
- add an illustrative 16-point CSV, CLI diagnostics, hosted execution, documentation, and regression tests while preserving circular and symmetric interfaces

## Validation

- python -m unittest discover -s tests -v (94 tests)
- uff check models tests
- uff format --check models tests
- committed directional CLI example (-65 MW, -40 MVAr, 100% boundary utilization)
- Markdown lint and workflow Prettier checks
- 46 affected-document links checked successfully
- independent 10,000-envelope / 30,000-allocation oracle (maximum component error 5.68e-14, no utilization overflow)
