### PR TITLE
Apply sampled capability envelopes to grid sequences

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -50,6 +50,18 @@ jobs:
           models/data/illustrative_directional_capability.csv
           --priority active
 
+      - name: Run directional grid-support sequence
+        run: >-
+          python models/grid_support_sequence.py
+          --frequency-hz-profile 49.5,49.5,50.5,50.5
+          --voltage-pu-profile 0.95,1.05,0.95,1.05
+          --duration-minutes-profile 1,1,1,1
+          --directional-curve-csv
+          models/data/illustrative_directional_capability.csv
+          --energy-capacity-mwh 1000 --initial-soc 0.5
+          --charge-efficiency 1 --discharge-efficiency 1
+          --priority reactive
+
       - name: Check Markdown links
         uses: lycheeverse/lychee-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ python models/grid_support_sequence.py `
   --limit-mva 100 --energy-capacity-mwh 100 `
   --initial-soc 0.50 --minimum-soc 0.20 `
   --charge-efficiency 1 --discharge-efficiency 1
+python models/grid_support_sequence.py `
+  --frequency-hz-profile 49.5,49.5,50.5,50.5 `
+  --voltage-pu-profile 0.95,1.05,0.95,1.05 `
+  --duration-minutes-profile 1,1,1,1 `
+  --directional-curve-csv `
+    models/data/illustrative_directional_capability.csv `
+  --energy-capacity-mwh 1000 --initial-soc 0.50 `
+  --charge-efficiency 1 --discharge-efficiency 1 `
+  --priority reactive
 python -m unittest discover -s tests -v
 ```
 

--- a/models/README.md
+++ b/models/README.md
@@ -182,10 +182,10 @@ settings before engineering use.
 
 [`frequency_watt.py`](frequency_watt.py) adds an illustrative frequency
 deadband, linear droop region, charge/discharge saturation, baseline schedule,
-and circular P-Q capability enforcement. Positive active power means discharge
-and injection into the grid; negative active power means charging. Below the
-lower deadband boundary, the controller increases injection. Above the upper
-deadband boundary, it reduces injection and can request charging.
+and circular or sampled P-Q capability enforcement. Positive active power means
+discharge and injection into the grid; negative active power means charging.
+Below the lower deadband boundary, the controller increases injection. Above
+the upper deadband boundary, it reduces injection and can request charging.
 
 The defaults assume a 50 Hz system, a `+/-0.05 Hz` deadband, and full response
 at a `+/-0.50 Hz` deviation. These values are educational examples, not
@@ -209,6 +209,19 @@ Storage-bounded active request: 70.000 MW
 Capability limited: true
 Delivered active power: 70.000 MW
 Delivered reactive power: 71.414 MVAr
+```
+
+Replace `--limit-mva` with `--curve-csv` or
+`--directional-curve-csv` to apply a sampled boundary after the same frequency,
+storage-power, ramp, and energy stages. For example, reactive-priority charging
+and absorption selects the directional charge/absorption quadrant:
+
+```powershell
+python models/frequency_watt.py `
+  --frequency-hz 50.5 --reactive-mvar -70 `
+  --directional-curve-csv `
+    models/data/illustrative_directional_capability.csv `
+  --priority reactive
 ```
 
 The model is static. It excludes sensor errors, higher-order measurement
@@ -289,7 +302,7 @@ Ramp limiting direction: ramp_up
 
 The integrated sequence is raw measurement, optional frequency filter,
 frequency-watt request, storage charge/discharge power bound, ramp bound,
-interval energy bound, and circular P-Q allocation.
+interval energy bound, and the selected circular or sampled P-Q allocation.
 The returned `ramp`, `energy`, and `capability` records preserve each stage for
 review. The ramp interval is the time available to move from the previous
 command; it is distinct from the energy response duration.
@@ -378,11 +391,11 @@ limitations of the single-interval model still apply.
 
 [`grid_support_sequence.py`](grid_support_sequence.py) composes the existing
 frequency-watt, Volt-VAR, measurement-filter, active-power-ramp, SOC, and
-circular P-Q models over a variable-duration profile. Each interval starts from
-the prior interval's delivered ending SOC. When ramp limits or frequency
-filtering are enabled, it also starts from the prior delivered active power or
-filtered frequency, so curtailment at one control layer changes the next
-interval's reachable state.
+circular or sampled P-Q models over a variable-duration profile. Each interval
+starts from the prior interval's delivered ending SOC. When ramp limits or
+frequency filtering are enabled, it also starts from the prior delivered active
+power or filtered frequency, so curtailment at one control layer changes the
+next interval's reachable state.
 
 Run three simultaneous frequency and voltage events with reactive-power
 priority:
@@ -417,6 +430,46 @@ accounting therefore keeps SOC at 0.45 instead of applying the pre-capability
 active request. `active`, `reactive`, and `proportional` priorities remain
 available for explicit service-conflict studies.
 
+Use `--curve-csv` or `--directional-curve-csv` instead of `--limit-mva` to
+apply the same strict sampled boundaries as the standalone allocator. With a
+directional envelope and no explicit `--reactive-base-mvar`, positive Volt-VAR
+requests use the injection-axis limit and negative requests use the
+absorption-axis limit. This keeps asymmetric MVAr capability visible rather
+than scaling both directions from one circular rating.
+
+Run a four-interval case that traverses discharge/injection,
+discharge/absorption, charge/injection, and charge/absorption:
+
+```powershell
+python models/grid_support_sequence.py `
+  --frequency-hz-profile 49.5,49.5,50.5,50.5 `
+  --voltage-pu-profile 0.95,1.05,0.95,1.05 `
+  --duration-minutes-profile 1,1,1,1 `
+  --directional-curve-csv `
+    models/data/illustrative_directional_capability.csv `
+  --energy-capacity-mwh 1000 --initial-soc 0.50 `
+  --charge-efficiency 1 --discharge-efficiency 1 `
+  --priority reactive
+```
+
+Expected directional results:
+
+```text
+Intervals: 4
+Limited intervals: 4
+Ending SOC: 0.4994
+Delivered active energy: 0.600 MWh
+Requested reactive service: 3.167 MVArh
+Delivered reactive service: 3.167 MVArh
+SOC balance error: 0.000e+00
+```
+
+The four delivered P/Q pairs are `(81.818, 50.000)`, `(80.000, -45.000)`,
+`(-65.000, 50.000)`, and `(-60.833, -45.000)` in MW/MVAr. Capability
+allocation remains after storage power, ramp, and energy bounds. Final SOC is
+recomputed from active power after capability curtailment, so the sequence does
+not debit energy for a pre-envelope request that the PCS cannot deliver.
+
 Active-energy totals preserve sign, so charging offsets discharge. Reactive
 service totals sum absolute MVArh because injection and absorption are both
 delivered voltage-support work; each interval row retains the Q direction.
@@ -424,7 +477,9 @@ delivered voltage-support work; each interval row retains the Q direction.
 The profile is an auditable control composition, not a dynamic network or
 electromagnetic-transient simulation. Each measurement is held constant for
 its interval. When ramp limits are enabled, they constrain the active setpoint
-before circular P-Q allocation; a higher-priority reactive request may then
-curtail delivered active power beyond that setpoint. Voltage feedback from
-reactive injection, frequency dynamics, controller latency, converter thermal
-limits, degradation, auxiliary demand, and uncertainty remain excluded.
+before P-Q allocation; a higher-priority reactive request may then curtail
+delivered active power beyond that setpoint. Sampled envelopes remain static
+external inputs and do not derive SOC, voltage, temperature, or grid-condition
+derating internally. Voltage feedback from reactive injection, frequency
+dynamics, controller latency, converter thermal limits, degradation, auxiliary
+demand, and uncertainty remain excluded.

--- a/models/frequency_watt.py
+++ b/models/frequency_watt.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import math
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Sequence
 
 try:
@@ -34,11 +35,23 @@ except ModuleNotFoundError:
 try:
     from models.pq_capability import (
         CapabilityResult,
+        DirectionalCapabilityEnvelope,
+        PiecewiseCapabilityCurve,
         PowerPriority,
-        allocate_power,
+        allocate_power_on_boundary,
+        load_capability_curve_csv,
+        load_directional_capability_csv,
     )
 except ModuleNotFoundError:
-    from pq_capability import CapabilityResult, PowerPriority, allocate_power
+    from pq_capability import (
+        CapabilityResult,
+        DirectionalCapabilityEnvelope,
+        PiecewiseCapabilityCurve,
+        PowerPriority,
+        allocate_power_on_boundary,
+        load_capability_curve_csv,
+        load_directional_capability_csv,
+    )
 
 try:
     from models.ramp_limits import (
@@ -130,7 +143,7 @@ def dispatch_frequency_watt(
     frequency_hz: float,
     baseline_active_mw: float,
     reactive_power_mvar: float,
-    apparent_power_limit_mva: float,
+    apparent_power_limit_mva: float | None,
     curve: FrequencyWattCurve = FrequencyWattCurve(),
     priority: PowerPriority | str = PowerPriority.ACTIVE,
     energy_state: StorageEnergyState | None = None,
@@ -141,6 +154,9 @@ def dispatch_frequency_watt(
     frequency_filter_config: FirstOrderFilterConfig | None = None,
     previous_filtered_frequency_hz: float | None = None,
     measurement_interval_seconds: float | None = None,
+    capability_envelope: (
+        PiecewiseCapabilityCurve | DirectionalCapabilityEnvelope | None
+    ) = None,
 ) -> FrequencyWattDispatch:
     """Evaluate frequency response with optional measurement and plant limits."""
 
@@ -227,10 +243,20 @@ def dispatch_frequency_watt(
             energy_state,
         )
         bounded_active_mw = energy.delivered_active_mw
-    capability = allocate_power(
+    if (apparent_power_limit_mva is None) == (capability_envelope is None):
+        raise ValueError(
+            "provide exactly one circular MVA limit or sampled capability envelope"
+        )
+    capability_boundary = (
+        capability_envelope
+        if capability_envelope is not None
+        else apparent_power_limit_mva
+    )
+    assert capability_boundary is not None
+    capability = allocate_power_on_boundary(
         bounded_active_mw,
         reactive_power_mvar,
-        apparent_power_limit_mva,
+        capability_boundary,
         priority,
     )
     delivered_energy = None
@@ -265,7 +291,10 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--frequency-hz", type=float, required=True)
     parser.add_argument("--baseline-active-mw", type=float, default=0.0)
     parser.add_argument("--reactive-mvar", type=float, default=0.0)
-    parser.add_argument("--limit-mva", type=float, required=True)
+    boundary = parser.add_mutually_exclusive_group(required=True)
+    boundary.add_argument("--limit-mva", type=float)
+    boundary.add_argument("--curve-csv", type=Path)
+    boundary.add_argument("--directional-curve-csv", type=Path)
     parser.add_argument(
         "--priority",
         choices=[item.value for item in PowerPriority],
@@ -295,6 +324,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
+    capability_envelope = None
+    if args.curve_csv is not None:
+        capability_envelope = load_capability_curve_csv(args.curve_csv)
+    elif args.directional_curve_csv is not None:
+        capability_envelope = load_directional_capability_csv(
+            args.directional_curve_csv
+        )
     curve = FrequencyWattCurve(
         nominal_frequency_hz=args.nominal_frequency_hz,
         deadband_hz=args.deadband_hz,
@@ -392,8 +428,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         frequency_filter_config=frequency_filter_config,
         previous_filtered_frequency_hz=args.previous_filtered_frequency_hz,
         measurement_interval_seconds=args.measurement_interval_seconds,
+        capability_envelope=capability_envelope,
     )
     capability = result.capability
+    if isinstance(capability_envelope, DirectionalCapabilityEnvelope):
+        print(
+            "Capability model: directional envelope "
+            f"(4 quadrants, {capability_envelope.point_count} points)"
+        )
+        quadrant = capability_envelope.quadrant_for(
+            result.bounded_active_mw,
+            args.reactive_mvar,
+        )
+        print(f"Capability quadrant: {quadrant.value}")
+    elif isinstance(capability_envelope, PiecewiseCapabilityCurve):
+        print(
+            "Capability model: piecewise curve "
+            f"({len(capability_envelope.points)} points)"
+        )
     print(f"Frequency: {result.frequency_hz:.3f} Hz")
     if result.frequency_filter is not None:
         print(

--- a/models/grid_support_sequence.py
+++ b/models/grid_support_sequence.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import math
 from dataclasses import dataclass, replace
+from pathlib import Path
 from typing import Sequence
 
 try:
@@ -13,7 +14,14 @@ try:
         dispatch_frequency_watt,
     )
     from models.measurement_filter import FirstOrderFilterConfig
-    from models.pq_capability import PowerPriority
+    from models.pq_capability import (
+        DirectionalCapabilityEnvelope,
+        PiecewiseCapabilityCurve,
+        PowerPriority,
+        load_capability_curve_csv,
+        load_directional_capability_csv,
+        reactive_axis_limit_mvar,
+    )
     from models.ramp_limits import RampRateLimits
     from models.volt_var import VoltVarCurve
 except ModuleNotFoundError:
@@ -24,7 +32,14 @@ except ModuleNotFoundError:
         dispatch_frequency_watt,
     )
     from measurement_filter import FirstOrderFilterConfig
-    from pq_capability import PowerPriority
+    from pq_capability import (
+        DirectionalCapabilityEnvelope,
+        PiecewiseCapabilityCurve,
+        PowerPriority,
+        load_capability_curve_csv,
+        load_directional_capability_csv,
+        reactive_axis_limit_mvar,
+    )
     from ramp_limits import RampRateLimits
     from volt_var import VoltVarCurve
 
@@ -99,7 +114,7 @@ def simulate_grid_support_sequence(
     baseline_active_mw: Sequence[float],
     duration_minutes: Sequence[float],
     energy_state: StorageEnergyState,
-    apparent_power_limit_mva: float,
+    apparent_power_limit_mva: float | None,
     frequency_curve: FrequencyWattCurve = FrequencyWattCurve(),
     voltage_curve: VoltVarCurve = VoltVarCurve(),
     reactive_base_mvar: float | None = None,
@@ -108,6 +123,9 @@ def simulate_grid_support_sequence(
     initial_active_mw: float | None = None,
     frequency_filter_config: FirstOrderFilterConfig | None = None,
     initial_filtered_frequency_hz: float | None = None,
+    capability_envelope: (
+        PiecewiseCapabilityCurve | DirectionalCapabilityEnvelope | None
+    ) = None,
 ) -> GridSupportSequence:
     """Compose grid-support controls while carrying plant state between intervals."""
 
@@ -120,12 +138,19 @@ def simulate_grid_support_sequence(
     energy_state.validate()
     frequency_curve.validate()
     voltage_curve.validate()
-    if not math.isfinite(apparent_power_limit_mva) or apparent_power_limit_mva <= 0.0:
-        raise ValueError("apparent_power_limit_mva must be finite and positive")
-    base_mvar = (
-        apparent_power_limit_mva if reactive_base_mvar is None else reactive_base_mvar
+    if (apparent_power_limit_mva is None) == (capability_envelope is None):
+        raise ValueError(
+            "provide exactly one circular MVA limit or sampled capability envelope"
+        )
+    capability_boundary = (
+        capability_envelope
+        if capability_envelope is not None
+        else apparent_power_limit_mva
     )
-    if not math.isfinite(base_mvar) or base_mvar <= 0.0:
+    assert capability_boundary is not None
+    if reactive_base_mvar is not None and (
+        not math.isfinite(reactive_base_mvar) or reactive_base_mvar <= 0.0
+    ):
         raise ValueError("reactive_base_mvar must be finite and positive")
 
     if (ramp_limits is None) != (initial_active_mw is None):
@@ -163,7 +188,12 @@ def simulate_grid_support_sequence(
         strict=True,
     ):
         request_pu = voltage_curve.reactive_request_pu(voltage)
-        requested_reactive_mvar = request_pu * base_mvar
+        interval_base_mvar = (
+            reactive_axis_limit_mvar(capability_boundary, request_pu)
+            if reactive_base_mvar is None
+            else reactive_base_mvar
+        )
+        requested_reactive_mvar = request_pu * interval_base_mvar
         dispatch = dispatch_frequency_watt(
             frequency_hz=frequency,
             baseline_active_mw=baseline,
@@ -181,6 +211,7 @@ def simulate_grid_support_sequence(
             measurement_interval_seconds=(
                 None if frequency_filter_config is None else duration * 60.0
             ),
+            capability_envelope=capability_envelope,
         )
         assert dispatch.delivered_energy is not None
         delivered_energy = dispatch.delivered_energy
@@ -327,7 +358,10 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--duration-minutes-profile", type=_parse_number_series, required=True
     )
-    parser.add_argument("--limit-mva", type=float, required=True)
+    boundary = parser.add_mutually_exclusive_group(required=True)
+    boundary.add_argument("--limit-mva", type=float)
+    boundary.add_argument("--curve-csv", type=Path)
+    boundary.add_argument("--directional-curve-csv", type=Path)
     parser.add_argument("--energy-capacity-mwh", type=float, required=True)
     parser.add_argument("--initial-soc", type=float, required=True)
     parser.add_argument("--minimum-soc", type=float, default=0.10)
@@ -378,6 +412,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     baselines = args.baseline_active_mw_profile
     if baselines is None:
         baselines = (0.0,) * interval_count
+
+    capability_envelope = None
+    if args.curve_csv is not None:
+        capability_envelope = load_capability_curve_csv(args.curve_csv)
+    elif args.directional_curve_csv is not None:
+        capability_envelope = load_directional_capability_csv(
+            args.directional_curve_csv
+        )
 
     ramp_inputs = (
         args.initial_active_mw,
@@ -449,8 +491,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         initial_active_mw=args.initial_active_mw,
         frequency_filter_config=filter_config,
         initial_filtered_frequency_hz=args.initial_filtered_frequency_hz,
+        capability_envelope=capability_envelope,
     )
 
+    if isinstance(capability_envelope, DirectionalCapabilityEnvelope):
+        print(
+            "Capability model: directional envelope "
+            f"(4 quadrants, {capability_envelope.point_count} points)"
+        )
+    elif isinstance(capability_envelope, PiecewiseCapabilityCurve):
+        print(
+            "Capability model: piecewise curve "
+            f"({len(capability_envelope.points)} points)"
+        )
+    else:
+        print(f"Capability model: circular limit ({args.limit_mva:.3f} MVA)")
     print(f"Intervals: {len(result.intervals)}")
     print(f"Limited intervals: {result.limited_interval_count}")
     print(f"Total duration: {result.total_duration_minutes:.3f} minutes")

--- a/models/pq_capability.py
+++ b/models/pq_capability.py
@@ -260,6 +260,9 @@ class DirectionalCapabilityEnvelope:
         return self.curves[self.quadrant_for(active_mw, reactive_mvar)]
 
 
+CapabilityBoundary = float | PiecewiseCapabilityCurve | DirectionalCapabilityEnvelope
+
+
 def _clip(value: float, limit: float) -> float:
     return max(-limit, min(limit, value))
 
@@ -443,6 +446,64 @@ def allocate_power_on_directional_envelope(
         requested_reactive_mvar,
         curve,
         priority,
+    )
+
+
+def allocate_power_on_boundary(
+    requested_active_mw: float,
+    requested_reactive_mvar: float,
+    boundary: CapabilityBoundary,
+    priority: PowerPriority | str = PowerPriority.ACTIVE,
+) -> CapabilityResult:
+    """Apply a circular, symmetric, or directional capability boundary."""
+
+    if isinstance(boundary, DirectionalCapabilityEnvelope):
+        return allocate_power_on_directional_envelope(
+            requested_active_mw,
+            requested_reactive_mvar,
+            boundary,
+            priority,
+        )
+    if isinstance(boundary, PiecewiseCapabilityCurve):
+        return allocate_power_on_curve(
+            requested_active_mw,
+            requested_reactive_mvar,
+            boundary,
+            priority,
+        )
+    if isinstance(boundary, (int, float)) and not isinstance(boundary, bool):
+        return allocate_power(
+            requested_active_mw,
+            requested_reactive_mvar,
+            float(boundary),
+            priority,
+        )
+    raise ValueError(
+        "capability boundary must be an MVA limit, piecewise curve, "
+        "or directional envelope"
+    )
+
+
+def reactive_axis_limit_mvar(
+    boundary: CapabilityBoundary,
+    reactive_mvar: float,
+) -> float:
+    """Return the applicable signed-direction reactive-axis magnitude."""
+
+    if not math.isfinite(reactive_mvar):
+        raise ValueError("reactive_mvar must be finite")
+    if isinstance(boundary, DirectionalCapabilityEnvelope):
+        return boundary.curve_for(0.0, reactive_mvar).maximum_reactive_mvar
+    if isinstance(boundary, PiecewiseCapabilityCurve):
+        return boundary.maximum_reactive_mvar
+    if isinstance(boundary, (int, float)) and not isinstance(boundary, bool):
+        limit = float(boundary)
+        if not math.isfinite(limit) or limit <= 0.0:
+            raise ValueError("apparent_power_limit_mva must be finite and positive")
+        return limit
+    raise ValueError(
+        "capability boundary must be an MVA limit, piecewise curve, "
+        "or directional envelope"
     )
 
 

--- a/tests/test_frequency_watt.py
+++ b/tests/test_frequency_watt.py
@@ -4,6 +4,7 @@ import contextlib
 import io
 import math
 import unittest
+from pathlib import Path
 
 from models.frequency_watt import (
     FrequencyWattCurve,
@@ -12,11 +13,17 @@ from models.frequency_watt import (
 )
 from models.energy_limits import EnergyBoundary, StorageEnergyState
 from models.measurement_filter import FirstOrderFilterConfig
-from models.pq_capability import PowerPriority
+from models.pq_capability import (
+    PowerPriority,
+    load_capability_curve_csv,
+    load_directional_capability_csv,
+)
 from models.ramp_limits import RampDirection, RampRateLimits
 
 
 class FrequencyWattTests(unittest.TestCase):
+    data_directory = Path(__file__).parents[1] / "models" / "data"
+
     def test_deadband_includes_both_boundaries(self):
         curve = FrequencyWattCurve()
         self.assertEqual(curve.active_adjustment_mw(49.95), 0.0)
@@ -276,6 +283,56 @@ class FrequencyWattTests(unittest.TestCase):
                                 100.0 + 1e-12,
                             )
 
+    def test_sampled_curve_limits_composed_frequency_dispatch(self):
+        curve = load_capability_curve_csv(
+            self.data_directory / "illustrative_capability_curve.csv"
+        )
+        result = dispatch_frequency_watt(
+            49.725,
+            20.0,
+            80.0,
+            None,
+            priority=PowerPriority.ACTIVE,
+            capability_envelope=curve,
+        )
+
+        self.assertAlmostEqual(result.bounded_active_mw, 70.0)
+        self.assertAlmostEqual(result.capability.active_mw, 70.0)
+        self.assertAlmostEqual(result.capability.reactive_mvar, 60.0)
+        self.assertTrue(result.capability.limited)
+
+    def test_directional_envelope_uses_requested_charge_absorption_quadrant(self):
+        envelope = load_directional_capability_csv(
+            self.data_directory / "illustrative_directional_capability.csv"
+        )
+        result = dispatch_frequency_watt(
+            50.5,
+            0.0,
+            -70.0,
+            None,
+            priority=PowerPriority.REACTIVE,
+            capability_envelope=envelope,
+        )
+
+        self.assertAlmostEqual(result.bounded_active_mw, -100.0)
+        self.assertAlmostEqual(result.capability.active_mw, -40.0)
+        self.assertAlmostEqual(result.capability.reactive_mvar, -70.0)
+
+    def test_capability_boundary_selection_is_strict(self):
+        curve = load_capability_curve_csv(
+            self.data_directory / "illustrative_capability_curve.csv"
+        )
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            dispatch_frequency_watt(50.0, 0.0, 0.0, None)
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            dispatch_frequency_watt(
+                50.0,
+                0.0,
+                0.0,
+                100.0,
+                capability_envelope=curve,
+            )
+
     def test_cli_reports_response_and_capability_limit(self):
         standard_output = io.StringIO()
         with contextlib.redirect_stdout(standard_output):
@@ -385,6 +442,30 @@ class FrequencyWattTests(unittest.TestCase):
         self.assertIn("Control frequency: 49.952 Hz", output)
         self.assertIn("Frequency-filter decay factor: 0.904837", output)
         self.assertIn("Droop adjustment: 0.000 MW", output)
+
+    def test_cli_runs_directional_frequency_dispatch(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--frequency-hz",
+                    "50.5",
+                    "--reactive-mvar",
+                    "-70",
+                    "--directional-curve-csv",
+                    str(
+                        self.data_directory / "illustrative_directional_capability.csv"
+                    ),
+                    "--priority",
+                    "reactive",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Capability model: directional envelope", output)
+        self.assertIn("Capability quadrant: charge_absorption", output)
+        self.assertIn("Delivered active power: -40.000 MW", output)
+        self.assertIn("Delivered reactive power: -70.000 MVAr", output)
 
     def test_cli_rejects_partial_energy_configuration(self):
         with self.assertRaisesRegex(ValueError, "must be provided together"):

--- a/tests/test_grid_support_sequence.py
+++ b/tests/test_grid_support_sequence.py
@@ -4,17 +4,24 @@ import contextlib
 import io
 import math
 import unittest
+from pathlib import Path
 
 from models.energy_limits import StorageEnergyState
 from models.frequency_watt import dispatch_frequency_watt
 from models.grid_support_sequence import main, simulate_grid_support_sequence
 from models.measurement_filter import FirstOrderFilterConfig
-from models.pq_capability import PowerPriority
+from models.pq_capability import (
+    PowerPriority,
+    load_capability_curve_csv,
+    load_directional_capability_csv,
+)
 from models.ramp_limits import RampRateLimits
 from models.volt_var import VoltVarCurve
 
 
 class GridSupportSequenceTests(unittest.TestCase):
+    data_directory = Path(__file__).parents[1] / "models" / "data"
+
     def test_simultaneous_services_carry_delivered_soc(self):
         result = simulate_grid_support_sequence(
             frequency_hz=(50.0, 49.5, 50.5),
@@ -81,6 +88,72 @@ class GridSupportSequenceTests(unittest.TestCase):
 
         self.assertEqual(result.intervals[0].dispatch, expected)
         self.assertAlmostEqual(result.intervals[0].requested_reactive_mvar, 50.0)
+
+    def test_directional_sequence_selects_all_four_quadrants(self):
+        envelope = load_directional_capability_csv(
+            self.data_directory / "illustrative_directional_capability.csv"
+        )
+        result = simulate_grid_support_sequence(
+            (49.5, 49.5, 50.5, 50.5),
+            (0.95, 1.05, 0.95, 1.05),
+            (0.0, 0.0, 0.0, 0.0),
+            (1.0, 1.0, 1.0, 1.0),
+            StorageEnergyState(
+                1000.0,
+                0.50,
+                charge_efficiency=1.0,
+                discharge_efficiency=1.0,
+            ),
+            None,
+            priority=PowerPriority.REACTIVE,
+            capability_envelope=envelope,
+        )
+
+        delivered = [
+            (
+                interval.dispatch.capability.active_mw,
+                interval.dispatch.capability.reactive_mvar,
+            )
+            for interval in result.intervals
+        ]
+        expected = (
+            (81.81818181818181, 50.0),
+            (80.0, -45.0),
+            (-65.0, 50.0),
+            (-60.833333333333336, -45.0),
+        )
+        for actual, target in zip(delivered, expected, strict=True):
+            self.assertAlmostEqual(actual[0], target[0])
+            self.assertAlmostEqual(actual[1], target[1])
+        for interval, expected_reactive_mvar in zip(
+            result.intervals,
+            (50.0, -45.0, 50.0, -45.0),
+            strict=True,
+        ):
+            self.assertAlmostEqual(
+                interval.requested_reactive_mvar,
+                expected_reactive_mvar,
+            )
+        self.assertAlmostEqual(result.soc_balance_error, 0.0)
+
+    def test_symmetric_sequence_uses_curve_reactive_axis(self):
+        curve = load_capability_curve_csv(
+            self.data_directory / "illustrative_capability_curve.csv"
+        )
+        result = simulate_grid_support_sequence(
+            (50.0,),
+            (0.95,),
+            (20.0,),
+            (15.0,),
+            StorageEnergyState(100.0, 0.50),
+            None,
+            priority=PowerPriority.ACTIVE,
+            capability_envelope=curve,
+        )
+        interval = result.intervals[0]
+        self.assertAlmostEqual(interval.requested_reactive_mvar, 50.0)
+        self.assertAlmostEqual(interval.dispatch.capability.active_mw, 20.0)
+        self.assertAlmostEqual(interval.dispatch.capability.reactive_mvar, 50.0)
 
     def test_soc_boundaries_carry_between_opposite_responses(self):
         result = simulate_grid_support_sequence(
@@ -206,6 +279,21 @@ class GridSupportSequenceTests(unittest.TestCase):
                 100.0,
                 initial_filtered_frequency_hz=50.0,
             )
+        curve = load_capability_curve_csv(
+            self.data_directory / "illustrative_capability_curve.csv"
+        )
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            simulate_grid_support_sequence((50.0,), (1.0,), (0.0,), (1.0,), state, None)
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            simulate_grid_support_sequence(
+                (50.0,),
+                (1.0,),
+                (0.0,),
+                (1.0,),
+                state,
+                100.0,
+                capability_envelope=curve,
+            )
 
     def test_operating_sweep_respects_soc_and_capability_boundaries(self):
         frequencies = (49.0, 49.8, 50.0, 50.2, 51.0)
@@ -305,6 +393,40 @@ class GridSupportSequenceTests(unittest.TestCase):
             main(common + ["--initial-active-mw", "0"])
         with self.assertRaisesRegex(ValueError, "must be provided together"):
             main(common + ["--initial-filtered-frequency-hz", "50"])
+
+    def test_cli_runs_directional_grid_support_sequence(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--frequency-hz-profile",
+                    "49.5,49.5,50.5,50.5",
+                    "--voltage-pu-profile",
+                    "0.95,1.05,0.95,1.05",
+                    "--duration-minutes-profile",
+                    "1,1,1,1",
+                    "--directional-curve-csv",
+                    str(
+                        self.data_directory / "illustrative_directional_capability.csv"
+                    ),
+                    "--energy-capacity-mwh",
+                    "1000",
+                    "--initial-soc",
+                    "0.5",
+                    "--charge-efficiency",
+                    "1",
+                    "--discharge-efficiency",
+                    "1",
+                    "--priority",
+                    "reactive",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Capability model: directional envelope", output)
+        self.assertIn("requested_q=50.000 MVAr", output)
+        self.assertIn("requested_q=-45.000 MVAr", output)
+        self.assertIn("delivered_p=-60.833 MW", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- let frequency-watt dispatch use circular, symmetric sampled, or directional four-quadrant P-Q boundaries
- carry sampled boundaries through multi-service sequences with sign-correct injection and absorption reactive bases
- preserve post-capability SOC accounting, add four-quadrant CLI coverage, and run the directional sequence in CI

## Validation
- `python -m unittest discover -s tests -v` (101 tests)
- committed circular, symmetric, directional, frequency-watt, and four-interval sequence commands
- Ruff check and format, compileall, Prettier, Markdown lint, 46 local links, and diff check
- independent oracle: 10,000 profiles / 44,758 intervals across all four quadrants; max P error 3.340e-13 MW, Q error 1.137e-13 MVAr, SOC error 1.110e-16