### PR TITLE
Add storage standing-loss accounting

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -35,6 +35,13 @@ jobs:
       - name: Test executable models
         run: python -m unittest discover -s tests -v
 
+      - name: Run storage standing-loss reference
+        run: >-
+          python models/energy_limits.py
+          --active-mw 0 --duration-minutes 120
+          --energy-capacity-mwh 100 --initial-soc 0.8
+          --auxiliary-load-mw 2 --self-discharge-rate-per-hour 0.01
+
       - name: Run sampled capability envelope
         run: >-
           python models/pq_capability.py

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ python models/energy_limits.py `
   --active-mw 100 --duration-minutes 60 `
   --energy-capacity-mwh 50 --initial-soc 0.50 `
   --minimum-soc 0.20 --discharge-efficiency 0.90
+python models/energy_limits.py `
+  --active-mw 0 --duration-minutes 120 `
+  --energy-capacity-mwh 100 --initial-soc 0.80 `
+  --auxiliary-load-mw 2 --self-discharge-rate-per-hour 0.01
 python models/energy_sequence.py `
   --active-mw-profile 50,50,50,-40 `
   --duration-minutes-profile 15,15,15,30 `

--- a/models/README.md
+++ b/models/README.md
@@ -145,13 +145,13 @@ reactive power means absorption at high voltage.
 The default breakpoints are configurable educational values, not a claim about
 any grid code, inverter setting, or interconnection agreement:
 
-| Region | Default Behavior |
-| --- | --- |
-| `V <= 0.92 pu` | Saturate at `+1.0 pu` reactive request. |
-| `0.92 < V < 0.98 pu` | Ramp linearly from injection to zero. |
-| `0.98 <= V <= 1.02 pu` | Hold a zero-reactive-power deadband. |
-| `1.02 < V < 1.08 pu` | Ramp linearly from zero to absorption. |
-| `V >= 1.08 pu` | Saturate at `-1.0 pu` reactive request. |
+| Region                 | Default Behavior                        |
+| ---------------------- | --------------------------------------- |
+| `V <= 0.92 pu`         | Saturate at `+1.0 pu` reactive request. |
+| `0.92 < V < 0.98 pu`   | Ramp linearly from injection to zero.   |
+| `0.98 <= V <= 1.02 pu` | Hold a zero-reactive-power deadband.    |
+| `1.02 < V < 1.08 pu`   | Ramp linearly from zero to absorption.  |
+| `V >= 1.08 pu`         | Saturate at `-1.0 pu` reactive request. |
 
 Run a low-voltage case where reactive-priority dispatch reduces active power to
 stay inside a 100 MVA limit:
@@ -340,9 +340,72 @@ inverter curtailment visible. The returned `energy` result describes the
 energy-bounded request, while `delivered_energy` recomputes ending SOC from the
 active power that remains after P-Q allocation.
 
-This is a single-interval energy accounting reference. It does not model
-self-discharge, auxiliary load, nonlinear efficiency, degradation, thermal
-derating, or uncertain capacity.
+## Auxiliary Demand And Self-Discharge
+
+Optional `--auxiliary-load-mw` and `--self-discharge-rate-per-hour` inputs add
+standing losses to the same energy boundary calculation. The stored-energy
+state follows this constant-coefficient interval equation:
+
+```text
+dE/dt = P_stored - P_auxiliary - lambda E
+```
+
+`P_stored` is negative AC discharge divided by discharge efficiency, or
+positive AC charge multiplied by charge efficiency. `lambda` is a continuous
+decay coefficient per hour, not a percentage value. For nonzero `lambda`, the
+model applies the exact zero-order-hold update:
+
+```text
+E_next = E_initial exp(-lambda dt)
+         + (P_stored - P_auxiliary) (1 - exp(-lambda dt)) / lambda
+```
+
+The zero-rate branch uses the exact linear limit, avoiding division by zero.
+`expm1` preserves accuracy for small rates and short intervals. Discharge and
+charge headroom are solved from the same update, so standing losses reduce
+available discharge and create additional charge room. The model rejects an
+interval when auxiliary and self-discharge losses would cross minimum SOC and
+the requested dispatch cannot supply enough charging energy to prevent it.
+
+Run an idle two-hour example with a 2 MW auxiliary demand and a continuous
+`0.01/h` self-discharge rate:
+
+```powershell
+python models/energy_limits.py `
+  --active-mw 0 --duration-minutes 120 `
+  --energy-capacity-mwh 100 --initial-soc 0.80 `
+  --auxiliary-load-mw 2 --self-discharge-rate-per-hour 0.01
+```
+
+Expected loss and state values:
+
+```text
+Ending SOC: 0.7446
+Auxiliary energy: 4.000 MWh
+Self-discharge energy: 1.544 MWh
+Stored energy change: -5.544 MWh
+```
+
+Every interval reports dispatch stored-energy change, auxiliary energy,
+self-discharge energy, and total stored-energy change. Their independent audit
+identity is:
+
+```text
+stored change = dispatch stored change - auxiliary energy - self-discharge
+```
+
+The terminology follows Sandia's distinction between
+[standby energy loss and self-discharge](https://www.osti.gov/servlets/purl/1368468).
+An NREL field study also shows why auxiliary demand must be treated as a stated
+project assumption: measured pump consumption changed with active power and
+SOC in its [utility-scale flow-battery demonstration](https://docs.nrel.gov/docs/fy18osti/71545.pdf).
+
+This reference deliberately uses one constant auxiliary load and one constant
+self-discharge rate. It assumes the storage medium supplies the auxiliary
+demand. Set auxiliary load to zero when a separate feeder supplies it, and
+account for that feeder outside this SOC model. Operating-state-dependent
+auxiliaries, nonlinear conversion efficiency, degradation, thermal derating,
+and uncertain capacity remain excluded.
 
 ## Multi-Interval Energy Trajectory
 
@@ -383,8 +446,8 @@ reconstructs final SOC from cumulative stored-energy change.
 
 This is a forward audit of a supplied power trajectory, not a scheduler or
 optimizer. It does not choose prices, services, or interval requests, and it
-does not compose frequency, ramp, or P-Q constraints across time. The standing
-loss, auxiliary-load, nonlinear-efficiency, degradation, thermal, and capacity
+does not compose frequency, ramp, or P-Q constraints across time. The constant
+loss assumptions and nonlinear-efficiency, degradation, thermal, and capacity
 limitations of the single-interval model still apply.
 
 ## Multi-Service Grid-Support Sequence
@@ -481,5 +544,5 @@ before P-Q allocation; a higher-priority reactive request may then curtail
 delivered active power beyond that setpoint. Sampled envelopes remain static
 external inputs and do not derive SOC, voltage, temperature, or grid-condition
 derating internally. Voltage feedback from reactive injection, frequency
-dynamics, controller latency, converter thermal limits, degradation, auxiliary
-demand, and uncertainty remain excluded.
+dynamics, controller latency, converter thermal limits, degradation,
+operating-state-dependent auxiliary demand, and uncertainty remain excluded.

--- a/models/README.md
+++ b/models/README.md
@@ -398,7 +398,7 @@ The terminology follows Sandia's distinction between
 [standby energy loss and self-discharge](https://www.osti.gov/servlets/purl/1368468).
 An NREL field study also shows why auxiliary demand must be treated as a stated
 project assumption: measured pump consumption changed with active power and
-SOC in its [utility-scale flow-battery demonstration](https://docs.nrel.gov/docs/fy18osti/71545.pdf).
+SOC in its [utility-scale flow-battery demonstration](https://www.osti.gov/biblio/1464729).
 
 This reference deliberately uses one constant auxiliary load and one constant
 self-discharge rate. It assumes the storage medium supplies the auxiliary

--- a/models/energy_limits.py
+++ b/models/energy_limits.py
@@ -22,6 +22,8 @@ class StorageEnergyState:
     maximum_soc: float = 0.90
     charge_efficiency: float = 0.95
     discharge_efficiency: float = 0.95
+    auxiliary_load_mw: float = 0.0
+    self_discharge_rate_per_hour: float = 0.0
 
     def validate(self) -> None:
         values = {
@@ -31,6 +33,8 @@ class StorageEnergyState:
             "maximum_soc": self.maximum_soc,
             "charge_efficiency": self.charge_efficiency,
             "discharge_efficiency": self.discharge_efficiency,
+            "auxiliary_load_mw": self.auxiliary_load_mw,
+            "self_discharge_rate_per_hour": self.self_discharge_rate_per_hour,
         }
         for name, value in values.items():
             if not math.isfinite(value):
@@ -47,6 +51,10 @@ class StorageEnergyState:
             raise ValueError("charge_efficiency must be within (0, 1]")
         if not 0.0 < self.discharge_efficiency <= 1.0:
             raise ValueError("discharge_efficiency must be within (0, 1]")
+        if self.auxiliary_load_mw < 0.0:
+            raise ValueError("auxiliary_load_mw must be nonnegative")
+        if self.self_discharge_rate_per_hour < 0.0:
+            raise ValueError("self_discharge_rate_per_hour must be nonnegative")
 
 
 @dataclass(frozen=True)
@@ -56,10 +64,27 @@ class EnergyLimitedDispatch:
     duration_minutes: float
     initial_soc: float
     ending_soc: float
+    dispatch_stored_energy_change_mwh: float
+    auxiliary_energy_mwh: float
+    self_discharge_energy_mwh: float
     stored_energy_change_mwh: float
     power_shortfall_mw: float
     energy_limited: bool
     limiting_boundary: EnergyBoundary | None
+
+
+def _retention_terms(
+    self_discharge_rate_per_hour: float,
+    duration_hours: float,
+) -> tuple[float, float]:
+    """Return exponential retention and constant-power influence in hours."""
+
+    if self_discharge_rate_per_hour == 0.0:
+        return 1.0, duration_hours
+    exponent = -self_discharge_rate_per_hour * duration_hours
+    retention = math.exp(exponent)
+    equivalent_hours = -math.expm1(exponent) / self_discharge_rate_per_hour
+    return retention, equivalent_hours
 
 
 def limit_active_power_by_energy(
@@ -76,36 +101,84 @@ def limit_active_power_by_energy(
         raise ValueError("duration_minutes must be finite and positive")
 
     duration_hours = duration_minutes / 60.0
+    initial_energy_mwh = state.initial_soc * state.energy_capacity_mwh
+    minimum_energy_mwh = state.minimum_soc * state.energy_capacity_mwh
+    maximum_energy_mwh = state.maximum_soc * state.energy_capacity_mwh
+    retention, equivalent_hours = _retention_terms(
+        state.self_discharge_rate_per_hour,
+        duration_hours,
+    )
+    loss_only_ending_energy_mwh = (
+        initial_energy_mwh * retention - state.auxiliary_load_mw * equivalent_hours
+    )
+
     if requested_active_mw > 0.0:
-        available_stored_energy_mwh = (
-            state.initial_soc - state.minimum_soc
-        ) * state.energy_capacity_mwh
-        maximum_discharge_mw = (
-            available_stored_energy_mwh * state.discharge_efficiency / duration_hours
+        available_stored_energy_mwh = loss_only_ending_energy_mwh - minimum_energy_mwh
+        if available_stored_energy_mwh < -1e-12:
+            raise ValueError(
+                "auxiliary and self-discharge losses cross minimum_soc before "
+                "applying requested discharge"
+            )
+        maximum_discharge_mw = max(
+            0.0,
+            available_stored_energy_mwh * state.discharge_efficiency / equivalent_hours,
         )
         delivered_active_mw = min(requested_active_mw, maximum_discharge_mw)
-        stored_energy_change_mwh = (
+        dispatch_stored_energy_change_mwh = (
             -delivered_active_mw * duration_hours / state.discharge_efficiency
         )
     elif requested_active_mw < 0.0:
-        available_storage_room_mwh = (
-            state.maximum_soc - state.initial_soc
-        ) * state.energy_capacity_mwh
-        maximum_charge_mw = available_storage_room_mwh / (
-            state.charge_efficiency * duration_hours
+        available_storage_room_mwh = maximum_energy_mwh - loss_only_ending_energy_mwh
+        maximum_charge_mw = max(
+            0.0,
+            available_storage_room_mwh / (state.charge_efficiency * equivalent_hours),
         )
         delivered_active_mw = max(requested_active_mw, -maximum_charge_mw)
-        stored_energy_change_mwh = (
+        dispatch_stored_energy_change_mwh = (
             -delivered_active_mw * duration_hours * state.charge_efficiency
         )
     else:
         delivered_active_mw = 0.0
-        stored_energy_change_mwh = 0.0
+        dispatch_stored_energy_change_mwh = 0.0
 
-    ending_soc = state.initial_soc + (
-        stored_energy_change_mwh / state.energy_capacity_mwh
+    if delivered_active_mw > 0.0:
+        dispatch_stored_power_mw = -delivered_active_mw / state.discharge_efficiency
+    else:
+        dispatch_stored_power_mw = -delivered_active_mw * state.charge_efficiency
+    ending_energy_mwh = (
+        loss_only_ending_energy_mwh + dispatch_stored_power_mw * equivalent_hours
     )
-    ending_soc = min(state.maximum_soc, max(state.minimum_soc, ending_soc))
+    if ending_energy_mwh < minimum_energy_mwh - 1e-10:
+        if requested_active_mw == 0.0:
+            raise ValueError(
+                "auxiliary and self-discharge losses cross minimum_soc without "
+                "a charging request"
+            )
+        raise ValueError(
+            "requested charging power is insufficient to cover auxiliary and "
+            "self-discharge losses before minimum_soc"
+        )
+    if ending_energy_mwh > maximum_energy_mwh + 1e-10:
+        raise RuntimeError("energy limiter failed to enforce maximum_soc")
+    ending_energy_mwh = min(
+        maximum_energy_mwh,
+        max(minimum_energy_mwh, ending_energy_mwh),
+    )
+
+    auxiliary_energy_mwh = state.auxiliary_load_mw * duration_hours
+    stored_energy_change_mwh = ending_energy_mwh - initial_energy_mwh
+    if state.self_discharge_rate_per_hour == 0.0:
+        self_discharge_energy_mwh = 0.0
+    else:
+        self_discharge_energy_mwh = (
+            dispatch_stored_energy_change_mwh
+            - auxiliary_energy_mwh
+            - stored_energy_change_mwh
+        )
+        if self_discharge_energy_mwh < -1e-12:
+            raise RuntimeError("self-discharge energy must be nonnegative")
+        self_discharge_energy_mwh = max(0.0, self_discharge_energy_mwh)
+    ending_soc = ending_energy_mwh / state.energy_capacity_mwh
     energy_limited = not math.isclose(
         delivered_active_mw,
         requested_active_mw,
@@ -125,6 +198,9 @@ def limit_active_power_by_energy(
         duration_minutes=duration_minutes,
         initial_soc=state.initial_soc,
         ending_soc=ending_soc,
+        dispatch_stored_energy_change_mwh=dispatch_stored_energy_change_mwh,
+        auxiliary_energy_mwh=auxiliary_energy_mwh,
+        self_discharge_energy_mwh=self_discharge_energy_mwh,
         stored_energy_change_mwh=stored_energy_change_mwh,
         power_shortfall_mw=abs(requested_active_mw - delivered_active_mw),
         energy_limited=energy_limited,
@@ -144,6 +220,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--maximum-soc", type=float, default=0.90)
     parser.add_argument("--charge-efficiency", type=float, default=0.95)
     parser.add_argument("--discharge-efficiency", type=float, default=0.95)
+    parser.add_argument("--auxiliary-load-mw", type=float, default=0.0)
+    parser.add_argument("--self-discharge-rate-per-hour", type=float, default=0.0)
     return parser.parse_args(argv)
 
 
@@ -156,6 +234,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         maximum_soc=args.maximum_soc,
         charge_efficiency=args.charge_efficiency,
         discharge_efficiency=args.discharge_efficiency,
+        auxiliary_load_mw=args.auxiliary_load_mw,
+        self_discharge_rate_per_hour=args.self_discharge_rate_per_hour,
     )
     result = limit_active_power_by_energy(
         args.active_mw,
@@ -172,6 +252,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(f"Limiting boundary: {boundary}")
     print(f"Initial SOC: {result.initial_soc:.4f}")
     print(f"Ending SOC: {result.ending_soc:.4f}")
+    print(
+        "Dispatch stored-energy change: "
+        f"{result.dispatch_stored_energy_change_mwh:.3f} MWh"
+    )
+    print(f"Auxiliary energy: {result.auxiliary_energy_mwh:.3f} MWh")
+    print(f"Self-discharge energy: {result.self_discharge_energy_mwh:.3f} MWh")
     print(f"Stored energy change: {result.stored_energy_change_mwh:.3f} MWh")
     print(f"Power shortfall: {result.power_shortfall_mw:.3f} MW")
     return 0

--- a/models/energy_sequence.py
+++ b/models/energy_sequence.py
@@ -30,6 +30,9 @@ class EnergyDispatchSequence:
     requested_ac_energy_mwh: float
     delivered_ac_energy_mwh: float
     curtailed_ac_energy_mwh: float
+    dispatch_stored_energy_change_mwh: float
+    auxiliary_energy_mwh: float
+    self_discharge_energy_mwh: float
     stored_energy_change_mwh: float
     soc_balance_error: float
     limited_interval_count: int
@@ -85,6 +88,15 @@ def simulate_energy_dispatch_sequence(
         / 60.0
         for interval in intervals
     )
+    dispatch_stored_energy_change_mwh = math.fsum(
+        interval.dispatch_stored_energy_change_mwh for interval in intervals
+    )
+    auxiliary_energy_mwh = math.fsum(
+        interval.auxiliary_energy_mwh for interval in intervals
+    )
+    self_discharge_energy_mwh = math.fsum(
+        interval.self_discharge_energy_mwh for interval in intervals
+    )
     stored_energy_change_mwh = math.fsum(
         interval.stored_energy_change_mwh for interval in intervals
     )
@@ -101,6 +113,9 @@ def simulate_energy_dispatch_sequence(
         requested_ac_energy_mwh=requested_ac_energy_mwh,
         delivered_ac_energy_mwh=delivered_ac_energy_mwh,
         curtailed_ac_energy_mwh=curtailed_ac_energy_mwh,
+        dispatch_stored_energy_change_mwh=dispatch_stored_energy_change_mwh,
+        auxiliary_energy_mwh=auxiliary_energy_mwh,
+        self_discharge_energy_mwh=self_discharge_energy_mwh,
         stored_energy_change_mwh=stored_energy_change_mwh,
         soc_balance_error=ending_soc - expected_ending_soc,
         limited_interval_count=sum(interval.energy_limited for interval in intervals),
@@ -144,6 +159,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--maximum-soc", type=float, default=0.90)
     parser.add_argument("--charge-efficiency", type=float, default=0.95)
     parser.add_argument("--discharge-efficiency", type=float, default=0.95)
+    parser.add_argument("--auxiliary-load-mw", type=float, default=0.0)
+    parser.add_argument("--self-discharge-rate-per-hour", type=float, default=0.0)
     return parser.parse_args(argv)
 
 
@@ -156,6 +173,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         maximum_soc=args.maximum_soc,
         charge_efficiency=args.charge_efficiency,
         discharge_efficiency=args.discharge_efficiency,
+        auxiliary_load_mw=args.auxiliary_load_mw,
+        self_discharge_rate_per_hour=args.self_discharge_rate_per_hour,
     )
     result = simulate_energy_dispatch_sequence(
         args.active_mw_profile,
@@ -171,6 +190,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(f"Requested AC energy: {result.requested_ac_energy_mwh:.3f} MWh")
     print(f"Delivered AC energy: {result.delivered_ac_energy_mwh:.3f} MWh")
     print(f"Curtailed AC energy: {result.curtailed_ac_energy_mwh:.3f} MWh")
+    print(
+        "Dispatch stored-energy change: "
+        f"{result.dispatch_stored_energy_change_mwh:.3f} MWh"
+    )
+    print(f"Auxiliary energy: {result.auxiliary_energy_mwh:.3f} MWh")
+    print(f"Self-discharge energy: {result.self_discharge_energy_mwh:.3f} MWh")
     print(f"Stored energy change: {result.stored_energy_change_mwh:.3f} MWh")
     print(f"SOC balance error: {result.soc_balance_error:.3e}")
     for interval_index, interval in enumerate(result.intervals, start=1):

--- a/models/frequency_watt.py
+++ b/models/frequency_watt.py
@@ -319,6 +319,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--maximum-soc", type=float)
     parser.add_argument("--charge-efficiency", type=float)
     parser.add_argument("--discharge-efficiency", type=float)
+    parser.add_argument("--auxiliary-load-mw", type=float)
+    parser.add_argument("--self-discharge-rate-per-hour", type=float)
     return parser.parse_args(argv)
 
 
@@ -346,6 +348,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.maximum_soc,
         args.charge_efficiency,
         args.discharge_efficiency,
+        args.auxiliary_load_mw,
+        args.self_discharge_rate_per_hour,
     )
     required_energy_inputs = (
         args.duration_minutes,
@@ -371,6 +375,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             ),
             discharge_efficiency=(
                 0.95 if args.discharge_efficiency is None else args.discharge_efficiency
+            ),
+            auxiliary_load_mw=(
+                0.0 if args.auxiliary_load_mw is None else args.auxiliary_load_mw
+            ),
+            self_discharge_rate_per_hour=(
+                0.0
+                if args.self_discharge_rate_per_hour is None
+                else args.self_discharge_rate_per_hour
             ),
         )
     ramp_inputs = (
@@ -482,6 +494,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"Energy limiting boundary: {boundary}")
         assert result.delivered_energy is not None
         print(f"Ending SOC: {result.delivered_energy.ending_soc:.4f}")
+        print(
+            f"Auxiliary energy: {result.delivered_energy.auxiliary_energy_mwh:.3f} MWh"
+        )
+        print(
+            "Self-discharge energy: "
+            f"{result.delivered_energy.self_discharge_energy_mwh:.3f} MWh"
+        )
     print(f"Capability priority: {capability.priority.value}")
     print(f"Capability limited: {str(capability.limited).lower()}")
     print(f"Delivered active power: {capability.active_mw:.3f} MW")

--- a/models/grid_support_sequence.py
+++ b/models/grid_support_sequence.py
@@ -73,6 +73,9 @@ class GridSupportSequence:
     requested_reactive_service_mvarh: float
     delivered_reactive_service_mvarh: float
     reactive_shortfall_service_mvarh: float
+    dispatch_stored_energy_change_mwh: float
+    auxiliary_energy_mwh: float
+    self_discharge_energy_mwh: float
     stored_energy_change_mwh: float
     soc_balance_error: float
     limited_interval_count: int
@@ -274,6 +277,21 @@ def simulate_grid_support_sequence(
         / 60.0
         for interval in intervals
     )
+    dispatch_stored_energy_change_mwh = math.fsum(
+        interval.dispatch.delivered_energy.dispatch_stored_energy_change_mwh
+        for interval in intervals
+        if interval.dispatch.delivered_energy is not None
+    )
+    auxiliary_energy_mwh = math.fsum(
+        interval.dispatch.delivered_energy.auxiliary_energy_mwh
+        for interval in intervals
+        if interval.dispatch.delivered_energy is not None
+    )
+    self_discharge_energy_mwh = math.fsum(
+        interval.dispatch.delivered_energy.self_discharge_energy_mwh
+        for interval in intervals
+        if interval.dispatch.delivered_energy is not None
+    )
     stored_energy_change_mwh = math.fsum(
         interval.dispatch.delivered_energy.stored_energy_change_mwh
         for interval in intervals
@@ -305,6 +323,9 @@ def simulate_grid_support_sequence(
         requested_reactive_service_mvarh=requested_reactive_service_mvarh,
         delivered_reactive_service_mvarh=delivered_reactive_service_mvarh,
         reactive_shortfall_service_mvarh=reactive_shortfall_service_mvarh,
+        dispatch_stored_energy_change_mwh=dispatch_stored_energy_change_mwh,
+        auxiliary_energy_mwh=auxiliary_energy_mwh,
+        self_discharge_energy_mwh=self_discharge_energy_mwh,
         stored_energy_change_mwh=stored_energy_change_mwh,
         soc_balance_error=ending_soc - expected_ending_soc,
         limited_interval_count=sum(interval_is_limited(item) for item in intervals),
@@ -368,6 +389,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--maximum-soc", type=float, default=0.90)
     parser.add_argument("--charge-efficiency", type=float, default=0.95)
     parser.add_argument("--discharge-efficiency", type=float, default=0.95)
+    parser.add_argument("--auxiliary-load-mw", type=float, default=0.0)
+    parser.add_argument("--self-discharge-rate-per-hour", type=float, default=0.0)
     parser.add_argument("--reactive-base-mvar", type=float)
     parser.add_argument(
         "--priority",
@@ -469,6 +492,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             maximum_soc=args.maximum_soc,
             charge_efficiency=args.charge_efficiency,
             discharge_efficiency=args.discharge_efficiency,
+            auxiliary_load_mw=args.auxiliary_load_mw,
+            self_discharge_rate_per_hour=args.self_discharge_rate_per_hour,
         ),
         apparent_power_limit_mva=args.limit_mva,
         frequency_curve=FrequencyWattCurve(
@@ -526,6 +551,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         "Reactive shortfall service: "
         f"{result.reactive_shortfall_service_mvarh:.3f} MVArh"
     )
+    print(
+        "Dispatch stored-energy change: "
+        f"{result.dispatch_stored_energy_change_mwh:.3f} MWh"
+    )
+    print(f"Auxiliary energy: {result.auxiliary_energy_mwh:.3f} MWh")
+    print(f"Self-discharge energy: {result.self_discharge_energy_mwh:.3f} MWh")
     print(f"Stored energy change: {result.stored_energy_change_mwh:.3f} MWh")
     print(f"SOC balance error: {result.soc_balance_error:.3e}")
     for index, interval in enumerate(result.intervals, start=1):

--- a/tests/test_energy_limits.py
+++ b/tests/test_energy_limits.py
@@ -65,6 +65,95 @@ class EnergyLimitsTests(unittest.TestCase):
         self.assertEqual(result.ending_soc, 0.50)
         self.assertFalse(result.energy_limited)
 
+    def test_idle_losses_follow_exact_exponential_solution(self):
+        state = StorageEnergyState(
+            100.0,
+            0.80,
+            auxiliary_load_mw=2.0,
+            self_discharge_rate_per_hour=0.01,
+        )
+        result = limit_active_power_by_energy(0.0, 120.0, state)
+
+        retention = math.exp(-0.01 * 2.0)
+        equivalent_hours = -math.expm1(-0.01 * 2.0) / 0.01
+        expected_ending_energy_mwh = 80.0 * retention - 2.0 * equivalent_hours
+        self.assertAlmostEqual(result.ending_soc, expected_ending_energy_mwh / 100.0)
+        self.assertAlmostEqual(result.auxiliary_energy_mwh, 4.0)
+        self.assertAlmostEqual(
+            result.self_discharge_energy_mwh,
+            80.0 - expected_ending_energy_mwh - 4.0,
+        )
+        self.assertFalse(result.energy_limited)
+
+    def test_losses_reduce_discharge_and_increase_charge_headroom(self):
+        discharge = limit_active_power_by_energy(
+            100.0,
+            60.0,
+            StorageEnergyState(
+                50.0,
+                0.50,
+                minimum_soc=0.20,
+                discharge_efficiency=0.90,
+                auxiliary_load_mw=1.0,
+                self_discharge_rate_per_hour=0.02,
+            ),
+        )
+        charge = limit_active_power_by_energy(
+            -100.0,
+            60.0,
+            StorageEnergyState(
+                50.0,
+                0.80,
+                maximum_soc=0.90,
+                charge_efficiency=0.80,
+                auxiliary_load_mw=1.0,
+                self_discharge_rate_per_hour=0.02,
+            ),
+        )
+
+        self.assertAlmostEqual(discharge.delivered_active_mw, 12.285449997000027)
+        self.assertAlmostEqual(discharge.ending_soc, 0.20)
+        self.assertIs(discharge.limiting_boundary, EnergyBoundary.MINIMUM_SOC)
+        self.assertAlmostEqual(charge.delivered_active_mw, -8.562708331944462)
+        self.assertAlmostEqual(charge.ending_soc, 0.90)
+        self.assertIs(charge.limiting_boundary, EnergyBoundary.MAXIMUM_SOC)
+
+    def test_loss_components_close_the_stored_energy_balance(self):
+        result = limit_active_power_by_energy(
+            -10.0,
+            30.0,
+            StorageEnergyState(
+                100.0,
+                0.50,
+                charge_efficiency=0.90,
+                auxiliary_load_mw=0.50,
+                self_discharge_rate_per_hour=0.005,
+            ),
+        )
+
+        reconstructed_change = (
+            result.dispatch_stored_energy_change_mwh
+            - result.auxiliary_energy_mwh
+            - result.self_discharge_energy_mwh
+        )
+        self.assertAlmostEqual(result.stored_energy_change_mwh, reconstructed_change)
+        self.assertGreater(result.self_discharge_energy_mwh, 0.0)
+
+    def test_losses_that_cannot_preserve_minimum_soc_are_rejected(self):
+        state = StorageEnergyState(
+            100.0,
+            0.20,
+            minimum_soc=0.20,
+            auxiliary_load_mw=1.0,
+            self_discharge_rate_per_hour=0.01,
+        )
+        with self.assertRaisesRegex(ValueError, "before applying requested discharge"):
+            limit_active_power_by_energy(10.0, 60.0, state)
+        with self.assertRaisesRegex(ValueError, "without a charging request"):
+            limit_active_power_by_energy(0.0, 60.0, state)
+        with self.assertRaisesRegex(ValueError, "insufficient"):
+            limit_active_power_by_energy(-0.10, 60.0, state)
+
     def test_boundary_states_block_only_the_outward_direction(self):
         lower = StorageEnergyState(100.0, 0.20, minimum_soc=0.20)
         upper = StorageEnergyState(100.0, 0.90, maximum_soc=0.90)
@@ -106,6 +195,22 @@ class EnergyLimitsTests(unittest.TestCase):
             limit_active_power_by_energy(math.nan, 15.0, StorageEnergyState(100.0, 0.5))
         with self.assertRaisesRegex(ValueError, "duration_minutes"):
             limit_active_power_by_energy(10.0, 0.0, StorageEnergyState(100.0, 0.5))
+        with self.assertRaisesRegex(ValueError, "auxiliary_load_mw"):
+            limit_active_power_by_energy(
+                10.0,
+                15.0,
+                StorageEnergyState(100.0, 0.5, auxiliary_load_mw=-0.1),
+            )
+        with self.assertRaisesRegex(ValueError, "self_discharge_rate_per_hour"):
+            limit_active_power_by_energy(
+                10.0,
+                15.0,
+                StorageEnergyState(
+                    100.0,
+                    0.5,
+                    self_discharge_rate_per_hour=-0.1,
+                ),
+            )
 
     def test_operating_sweep_never_crosses_soc_boundaries(self):
         for initial_soc in (0.20, 0.35, 0.75, 0.90):
@@ -154,6 +259,31 @@ class EnergyLimitsTests(unittest.TestCase):
         self.assertIn("Energy limited: true", output)
         self.assertIn("Limiting boundary: minimum_soc", output)
         self.assertIn("Ending SOC: 0.2000", output)
+
+    def test_cli_reports_auxiliary_and_self_discharge_energy(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--active-mw",
+                    "0",
+                    "--duration-minutes",
+                    "120",
+                    "--energy-capacity-mwh",
+                    "100",
+                    "--initial-soc",
+                    "0.8",
+                    "--auxiliary-load-mw",
+                    "2",
+                    "--self-discharge-rate-per-hour",
+                    "0.01",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Ending SOC: 0.7446", output)
+        self.assertIn("Auxiliary energy: 4.000 MWh", output)
+        self.assertIn("Self-discharge energy: 1.544 MWh", output)
 
 
 if __name__ == "__main__":

--- a/tests/test_energy_sequence.py
+++ b/tests/test_energy_sequence.py
@@ -54,6 +54,52 @@ class EnergySequenceTests(unittest.TestCase):
         self.assertEqual(result.initial_soc, state.initial_soc)
         self.assertEqual(result.ending_soc, expected.ending_soc)
 
+    def test_split_idle_intervals_match_one_exact_loss_interval(self):
+        state = StorageEnergyState(
+            100.0,
+            0.80,
+            auxiliary_load_mw=2.0,
+            self_discharge_rate_per_hour=0.01,
+        )
+        combined = limit_active_power_by_energy(0.0, 120.0, state)
+        split = simulate_energy_dispatch_sequence(
+            (0.0, 0.0, 0.0, 0.0),
+            (30.0, 30.0, 30.0, 30.0),
+            state,
+        )
+
+        self.assertAlmostEqual(split.ending_soc, combined.ending_soc)
+        self.assertAlmostEqual(split.auxiliary_energy_mwh, 4.0)
+        self.assertAlmostEqual(
+            split.self_discharge_energy_mwh,
+            combined.self_discharge_energy_mwh,
+        )
+        self.assertEqual(split.dispatch_stored_energy_change_mwh, 0.0)
+
+    def test_sequence_loss_aggregates_close_energy_identity(self):
+        result = simulate_energy_dispatch_sequence(
+            (10.0, -5.0, 0.0),
+            (15.0, 30.0, 45.0),
+            StorageEnergyState(
+                100.0,
+                0.60,
+                charge_efficiency=0.90,
+                discharge_efficiency=0.90,
+                auxiliary_load_mw=0.20,
+                self_discharge_rate_per_hour=0.002,
+            ),
+        )
+
+        reconstructed_change = (
+            result.dispatch_stored_energy_change_mwh
+            - result.auxiliary_energy_mwh
+            - result.self_discharge_energy_mwh
+        )
+        self.assertAlmostEqual(result.stored_energy_change_mwh, reconstructed_change)
+        self.assertAlmostEqual(result.auxiliary_energy_mwh, 0.30)
+        self.assertGreater(result.self_discharge_energy_mwh, 0.0)
+        self.assertAlmostEqual(result.soc_balance_error, 0.0)
+
     def test_mixed_profile_closes_stored_energy_and_soc_balance(self):
         state = StorageEnergyState(
             energy_capacity_mwh=120.0,
@@ -160,6 +206,32 @@ class EnergySequenceTests(unittest.TestCase):
             output,
         )
         self.assertIn("boundary=minimum_soc", output)
+
+    def test_cli_reports_sequence_loss_totals(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--active-mw-profile",
+                    "0,0",
+                    "--duration-minutes-profile",
+                    "60,60",
+                    "--energy-capacity-mwh",
+                    "100",
+                    "--initial-soc",
+                    "0.8",
+                    "--auxiliary-load-mw",
+                    "2",
+                    "--self-discharge-rate-per-hour",
+                    "0.01",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Ending SOC: 0.7446", output)
+        self.assertIn("Auxiliary energy: 4.000 MWh", output)
+        self.assertIn("Self-discharge energy: 1.544 MWh", output)
 
 
 if __name__ == "__main__":

--- a/tests/test_frequency_watt.py
+++ b/tests/test_frequency_watt.py
@@ -240,6 +240,29 @@ class FrequencyWattTests(unittest.TestCase):
         self.assertAlmostEqual(result.capability.active_mw, 60.0)
         self.assertAlmostEqual(result.delivered_energy.ending_soc, 0.30)
 
+    def test_delivered_soc_includes_auxiliary_and_self_discharge_losses(self):
+        result = dispatch_frequency_watt(
+            50.0,
+            0.0,
+            0.0,
+            100.0,
+            energy_state=StorageEnergyState(
+                100.0,
+                0.80,
+                auxiliary_load_mw=2.0,
+                self_discharge_rate_per_hour=0.01,
+            ),
+            duration_minutes=120.0,
+        )
+
+        assert result.delivered_energy is not None
+        self.assertAlmostEqual(result.delivered_energy.ending_soc, 0.7445562852589148)
+        self.assertAlmostEqual(result.delivered_energy.auxiliary_energy_mwh, 4.0)
+        self.assertAlmostEqual(
+            result.delivered_energy.self_discharge_energy_mwh,
+            1.544371474108516,
+        )
+
     def test_energy_state_and_duration_must_be_provided_together(self):
         state = StorageEnergyState(100.0, 0.5)
         with self.assertRaisesRegex(ValueError, "must be provided together"):
@@ -386,6 +409,34 @@ class FrequencyWattTests(unittest.TestCase):
         self.assertIn("Energy limiting boundary: minimum_soc", output)
         self.assertIn("Ending SOC: 0.2000", output)
 
+    def test_cli_reports_delivered_storage_losses(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--frequency-hz",
+                    "50",
+                    "--limit-mva",
+                    "100",
+                    "--duration-minutes",
+                    "120",
+                    "--energy-capacity-mwh",
+                    "100",
+                    "--initial-soc",
+                    "0.8",
+                    "--auxiliary-load-mw",
+                    "2",
+                    "--self-discharge-rate-per-hour",
+                    "0.01",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Ending SOC: 0.7446", output)
+        self.assertIn("Auxiliary energy: 4.000 MWh", output)
+        self.assertIn("Self-discharge energy: 1.544 MWh", output)
+
     def test_cli_reports_ramp_limited_frequency_response(self):
         standard_output = io.StringIO()
         with contextlib.redirect_stdout(standard_output):
@@ -477,6 +528,17 @@ class FrequencyWattTests(unittest.TestCase):
                     "100",
                     "--minimum-soc",
                     "0.2",
+                ]
+            )
+        with self.assertRaisesRegex(ValueError, "must be provided together"):
+            main(
+                [
+                    "--frequency-hz",
+                    "50",
+                    "--limit-mva",
+                    "100",
+                    "--auxiliary-load-mw",
+                    "1",
                 ]
             )
 

--- a/tests/test_grid_support_sequence.py
+++ b/tests/test_grid_support_sequence.py
@@ -242,6 +242,31 @@ class GridSupportSequenceTests(unittest.TestCase):
         self.assertGreaterEqual(result.active_shortfall_energy_mwh, 0.0)
         self.assertGreaterEqual(result.reactive_shortfall_service_mvarh, 0.0)
 
+    def test_storage_losses_carry_through_grid_support_sequence(self):
+        result = simulate_grid_support_sequence(
+            (50.0, 50.0),
+            (1.0, 1.0),
+            (0.0, 0.0),
+            (60.0, 60.0),
+            StorageEnergyState(
+                100.0,
+                0.80,
+                auxiliary_load_mw=2.0,
+                self_discharge_rate_per_hour=0.01,
+            ),
+            100.0,
+        )
+
+        self.assertAlmostEqual(result.ending_soc, 0.7445562852589148)
+        self.assertEqual(result.dispatch_stored_energy_change_mwh, 0.0)
+        self.assertAlmostEqual(result.auxiliary_energy_mwh, 4.0)
+        self.assertAlmostEqual(result.self_discharge_energy_mwh, 1.544371474108516)
+        self.assertAlmostEqual(
+            result.stored_energy_change_mwh,
+            -result.auxiliary_energy_mwh - result.self_discharge_energy_mwh,
+        )
+        self.assertAlmostEqual(result.soc_balance_error, 0.0)
+
     def test_profile_and_optional_state_inputs_are_validated(self):
         state = StorageEnergyState(100.0, 0.50)
         with self.assertRaisesRegex(ValueError, "at least one interval"):
@@ -373,6 +398,36 @@ class GridSupportSequenceTests(unittest.TestCase):
             output,
         )
         self.assertIn("limits=storage_power,capability", output)
+
+    def test_cli_reports_grid_support_storage_losses(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--frequency-hz-profile",
+                    "50,50",
+                    "--voltage-pu-profile",
+                    "1,1",
+                    "--duration-minutes-profile",
+                    "60,60",
+                    "--limit-mva",
+                    "100",
+                    "--energy-capacity-mwh",
+                    "100",
+                    "--initial-soc",
+                    "0.8",
+                    "--auxiliary-load-mw",
+                    "2",
+                    "--self-discharge-rate-per-hour",
+                    "0.01",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Ending SOC: 0.7446", output)
+        self.assertIn("Auxiliary energy: 4.000 MWh", output)
+        self.assertIn("Self-discharge energy: 1.544 MWh", output)
 
     def test_cli_rejects_partial_ramp_and_filter_configuration(self):
         common = [


### PR DESCRIPTION
## Summary

- add exact constant-coefficient auxiliary-load and self-discharge accounting to the shared SOC limiter
- carry separate dispatch, auxiliary, self-discharge, and total stored-energy terms through energy, frequency-watt, and grid-support sequences
- adjust charge/discharge headroom for standing losses and reject intervals whose requested dispatch cannot preserve minimum SOC
- expose the new assumptions through every relevant CLI, document the equation and separate-feeder boundary, and run a canonical case in CI
- add twelve regression tests spanning exact decay, both SOC boundaries, balance closure, invalid inputs, reserve failures, aggregates, and all composed command paths

## Validation

- 113 unit tests pass
- Ruff lint and formatting pass for all model and test files
- Markdown lint and Prettier pass for the documentation and workflow
- Python compilation and Git whitespace checks pass
- all four CLI surfaces reproduce 0.7446 ending SOC, 4.000 MWh auxiliary energy, and 1.544 MWh self-discharge for the canonical case
- a 20,000-case 50-digit Decimal oracle verified 19,605 feasible dispatches and 395 expected reserve failures; maximum delivered-power error was 3.013e-12 MW
- 200 independent RK4 comparisons had maximum ending-energy disagreement of 1.103e-11 MWh
