### PR TITLE
Add external temperature power derating

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -57,6 +57,13 @@ jobs:
           models/data/illustrative_directional_capability.csv
           --priority active
 
+      - name: Run external temperature power derating
+        run: >-
+          python models/temperature_derating.py
+          --active-mw -90 --temperature-c 40
+          --max-discharge-mw 80 --max-charge-mw 100
+          --curve-csv models/data/illustrative_temperature_derating.csv
+
       - name: Run directional grid-support sequence
         run: >-
           python models/grid_support_sequence.py

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ and project teams.
 - [Executable frequency-watt dispatch reference](models/README.md#frequency-watt-dispatch-reference)
 - [Executable frequency measurement filter](models/README.md#frequency-measurement-filter)
 - [Executable active-power ramp limits](models/README.md#active-power-ramp-limits)
+- [Executable external temperature power derating](models/README.md#external-temperature-power-derating)
 - [Executable SOC and response-duration limits](models/README.md#soc-and-response-duration-limits)
 - [Executable multi-interval energy trajectory](models/README.md#multi-interval-energy-trajectory)
 - [Executable multi-service grid-support sequence](models/README.md#multi-service-grid-support-sequence)
@@ -121,6 +122,10 @@ python models/measurement_filter.py `
 python models/ramp_limits.py `
   --active-mw 80 --previous-active-mw 20 --interval-seconds 30 `
   --ramp-up-mw-per-minute 40 --ramp-down-mw-per-minute 60
+python models/temperature_derating.py `
+  --active-mw -90 --temperature-c 40 `
+  --max-discharge-mw 80 --max-charge-mw 100 `
+  --curve-csv models/data/illustrative_temperature_derating.csv
 python models/energy_limits.py `
   --active-mw 100 --duration-minutes 60 `
   --energy-capacity-mwh 50 --initial-soc 0.50 `

--- a/models/README.md
+++ b/models/README.md
@@ -125,11 +125,12 @@ python -m unittest discover -s tests -v
 - Every sampled quadrant curve is concave and linearly interpolated. The
   symmetric input mirrors one curve; the directional input requires four
   curves and consistent shared-axis intercepts.
-- Dynamic current limits, voltage dependence, and temperature derating are
-  not calculated internally. They can be represented only after an external
-  study supplies the applicable sampled envelope. SOC and interval-duration
-  limits can be composed through `energy_limits.py`, but are not inherent to
-  the P-Q allocator.
+- Dynamic current limits and voltage dependence are not calculated internally.
+  Temperature-dependent active-power limits can be composed through
+  `temperature_derating.py`, but only after an external study supplies the
+  applicable sampled envelope. SOC and interval-duration limits can be
+  composed through `energy_limits.py`; neither layer is inherent to the P-Q
+  allocator.
 - The allocator is static and does not model control-loop response.
 - Grid-code, protection, and plant-controller constraints remain project
   inputs.
@@ -228,11 +229,12 @@ The model is static. It excludes sensor errors, higher-order measurement
 dynamics, control-loop dynamics, recovery logic, and interactions with
 plant-level dispatch. Optional filter arguments apply a first-order frequency
 measurement filter before deadband and droop evaluation. Optional ramp
-arguments enforce asymmetric signed active-power slew limits before SOC and P-Q
-allocation. Optional energy arguments then enforce SOC reserve, response
-duration, and charge/discharge efficiency. Replace every frequency, filter,
-power, ramp, energy, efficiency, baseline, and priority assumption with
-project-controlled values before engineering use.
+arguments enforce asymmetric signed active-power slew limits. An optional
+externally supplied temperature curve then applies a hard active-power envelope
+before SOC and P-Q allocation. Optional energy arguments enforce SOC reserve,
+response duration, and charge/discharge efficiency. Replace every frequency,
+filter, power, ramp, temperature, energy, efficiency, baseline, and priority
+assumption with project-controlled values before engineering use.
 
 ## Frequency Measurement Filter
 
@@ -302,10 +304,57 @@ Ramp limiting direction: ramp_up
 
 The integrated sequence is raw measurement, optional frequency filter,
 frequency-watt request, storage charge/discharge power bound, ramp bound,
-interval energy bound, and the selected circular or sampled P-Q allocation.
-The returned `ramp`, `energy`, and `capability` records preserve each stage for
-review. The ramp interval is the time available to move from the previous
-command; it is distinct from the energy response duration.
+optional hard temperature envelope, interval energy bound, and the selected
+circular or sampled P-Q allocation. The returned `ramp`,
+`temperature_derating`, `energy`, and `capability` records preserve each stage
+for review. The ramp interval is the time available to move from the previous
+command; it is distinct from the energy response duration. A newly reduced
+temperature limit takes precedence over the ramp stage so a carried setpoint
+cannot remain outside the current operating envelope.
+
+## External Temperature Power Derating
+
+[`temperature_derating.py`](temperature_derating.py) consumes an externally
+supplied table of temperature, maximum discharge power, and maximum charge
+power. Temperatures must be strictly increasing; every power limit must be
+finite and nonnegative. The model linearly interpolates between samples and
+clamps outside temperatures to the nearest endpoint instead of extrapolating.
+It reports the bracketing temperatures, interpolation fraction, endpoint-clamp
+status, sampled limits, nameplate-constrained effective limits, and delivered
+active power.
+
+Run the committed illustrative 40 C charging case:
+
+```powershell
+python models/temperature_derating.py `
+  --active-mw -90 --temperature-c 40 `
+  --max-discharge-mw 80 --max-charge-mw 100 `
+  --curve-csv models/data/illustrative_temperature_derating.csv
+```
+
+Expected key values:
+
+```text
+Sampled discharge limit: 85.000 MW
+Sampled charge limit: 65.000 MW
+Effective discharge limit: 80.000 MW
+Effective charge limit: 65.000 MW
+Delivered active power: -65.000 MW
+Temperature limited: true
+```
+
+The committed values deliberately show different cold and hot charge/discharge
+limits. They are test data, not ratings for a battery, inverter, or thermal
+management system. The temperature input is also external: this model does not
+estimate cell, module, coolant, enclosure, or ambient temperature. Project use
+must define the measured temperature, sensor policy, hysteresis, dwell time,
+fault handling, and the study or vendor data behind every sample.
+
+Add `--temperature-c` and `--temperature-derating-csv` to
+`frequency_watt.py`, or a comma-separated `--temperature-c-profile` plus the
+same CSV to `grid_support_sequence.py`. Both inputs are required as a pair.
+The effective limit is the smaller of the sampled limit and the configured
+frequency-watt nameplate limit in each direction.
 
 ## SOC And Response-Duration Limits
 
@@ -454,11 +503,11 @@ limitations of the single-interval model still apply.
 
 [`grid_support_sequence.py`](grid_support_sequence.py) composes the existing
 frequency-watt, Volt-VAR, measurement-filter, active-power-ramp, SOC, and
-circular or sampled P-Q models over a variable-duration profile. Each interval
-starts from the prior interval's delivered ending SOC. When ramp limits or
-frequency filtering are enabled, it also starts from the prior delivered active
-power or filtered frequency, so curtailment at one control layer changes the
-next interval's reachable state.
+optional temperature-derating and circular or sampled P-Q models over a
+variable-duration profile. Each interval starts from the prior interval's
+delivered ending SOC. When ramp limits or frequency filtering are enabled, it
+also starts from the prior delivered active power or filtered frequency, so
+curtailment at one control layer changes the next interval's reachable state.
 
 Run three simultaneous frequency and voltage events with reactive-power
 priority:
@@ -529,9 +578,10 @@ SOC balance error: 0.000e+00
 
 The four delivered P/Q pairs are `(81.818, 50.000)`, `(80.000, -45.000)`,
 `(-65.000, 50.000)`, and `(-60.833, -45.000)` in MW/MVAr. Capability
-allocation remains after storage power, ramp, and energy bounds. Final SOC is
-recomputed from active power after capability curtailment, so the sequence does
-not debit energy for a pre-envelope request that the PCS cannot deliver.
+allocation remains after storage power, ramp, temperature, and energy bounds.
+Final SOC is recomputed from active power after capability curtailment, so the
+sequence does not debit energy for a pre-envelope request that the PCS cannot
+deliver.
 
 Active-energy totals preserve sign, so charging offsets discharge. Reactive
 service totals sum absolute MVArh because injection and absorption are both
@@ -540,9 +590,10 @@ delivered voltage-support work; each interval row retains the Q direction.
 The profile is an auditable control composition, not a dynamic network or
 electromagnetic-transient simulation. Each measurement is held constant for
 its interval. When ramp limits are enabled, they constrain the active setpoint
-before P-Q allocation; a higher-priority reactive request may then curtail
-delivered active power beyond that setpoint. Sampled envelopes remain static
-external inputs and do not derive SOC, voltage, temperature, or grid-condition
-derating internally. Voltage feedback from reactive injection, frequency
-dynamics, controller latency, converter thermal limits, degradation,
-operating-state-dependent auxiliary demand, and uncertainty remain excluded.
+before temperature, energy, and P-Q limits; a higher-priority reactive request
+may then curtail delivered active power beyond that setpoint. Sampled P-Q and
+temperature envelopes remain static external inputs. They do not derive SOC,
+voltage, temperature, or grid-condition derating internally. Voltage feedback
+from reactive injection, frequency dynamics, controller latency, temperature
+estimation, degradation, operating-state-dependent auxiliary demand, and
+uncertainty remain excluded.

--- a/models/data/illustrative_temperature_derating.csv
+++ b/models/data/illustrative_temperature_derating.csv
@@ -1,0 +1,7 @@
+temperature_c,max_discharge_mw,max_charge_mw
+-20,30,0
+0,70,40
+20,100,80
+35,100,80
+45,70,50
+55,20,10

--- a/models/frequency_watt.py
+++ b/models/frequency_watt.py
@@ -66,6 +66,21 @@ except ModuleNotFoundError:
         limit_active_power_by_ramp,
     )
 
+try:
+    from models.temperature_derating import (
+        TemperatureLimitedDispatch,
+        TemperaturePowerDeratingCurve,
+        limit_active_power_by_temperature,
+        load_temperature_derating_csv,
+    )
+except ModuleNotFoundError:
+    from temperature_derating import (
+        TemperatureLimitedDispatch,
+        TemperaturePowerDeratingCurve,
+        limit_active_power_by_temperature,
+        load_temperature_derating_csv,
+    )
+
 
 @dataclass(frozen=True)
 class FrequencyWattCurve:
@@ -130,10 +145,12 @@ class FrequencyWattDispatch:
     unconstrained_active_mw: float
     power_bounded_active_mw: float
     ramp_bounded_active_mw: float
+    temperature_bounded_active_mw: float
     bounded_active_mw: float
     storage_power_limited: bool
     frequency_filter: FirstOrderFilterStep | None
     ramp: RampLimitedDispatch | None
+    temperature_derating: TemperatureLimitedDispatch | None
     energy: EnergyLimitedDispatch | None
     delivered_energy: EnergyLimitedDispatch | None
     capability: CapabilityResult
@@ -157,6 +174,8 @@ def dispatch_frequency_watt(
     capability_envelope: (
         PiecewiseCapabilityCurve | DirectionalCapabilityEnvelope | None
     ) = None,
+    temperature_c: float | None = None,
+    temperature_derating_curve: TemperaturePowerDeratingCurve | None = None,
 ) -> FrequencyWattDispatch:
     """Evaluate frequency response with optional measurement and plant limits."""
 
@@ -164,6 +183,10 @@ def dispatch_frequency_watt(
         raise ValueError("baseline_active_mw must be finite")
     if not math.isfinite(frequency_hz) or frequency_hz <= 0.0:
         raise ValueError("frequency_hz must be finite and positive")
+    if (temperature_c is None) != (temperature_derating_curve is None):
+        raise ValueError(
+            "temperature_c and temperature_derating_curve must be provided together"
+        )
 
     filter_inputs = (
         frequency_filter_config,
@@ -234,11 +257,22 @@ def dispatch_frequency_watt(
             ramp_limits,
         )
         ramp_bounded_active_mw = ramp.delivered_active_mw
+    temperature_derating = None
+    temperature_bounded_active_mw = ramp_bounded_active_mw
+    if temperature_c is not None and temperature_derating_curve is not None:
+        temperature_derating = limit_active_power_by_temperature(
+            ramp_bounded_active_mw,
+            temperature_c,
+            curve.max_discharge_mw,
+            curve.max_charge_mw,
+            temperature_derating_curve,
+        )
+        temperature_bounded_active_mw = temperature_derating.delivered_active_mw
     energy = None
-    bounded_active_mw = ramp_bounded_active_mw
+    bounded_active_mw = temperature_bounded_active_mw
     if energy_state is not None and duration_minutes is not None:
         energy = limit_active_power_by_energy(
-            ramp_bounded_active_mw,
+            temperature_bounded_active_mw,
             duration_minutes,
             energy_state,
         )
@@ -274,10 +308,12 @@ def dispatch_frequency_watt(
         unconstrained_active_mw=unconstrained_active_mw,
         power_bounded_active_mw=power_bounded_active_mw,
         ramp_bounded_active_mw=ramp_bounded_active_mw,
+        temperature_bounded_active_mw=temperature_bounded_active_mw,
         bounded_active_mw=bounded_active_mw,
         storage_power_limited=storage_power_limited,
         frequency_filter=frequency_filter,
         ramp=ramp,
+        temperature_derating=temperature_derating,
         energy=energy,
         delivered_energy=delivered_energy,
         capability=capability,
@@ -305,6 +341,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--full-response-deviation-hz", type=float, default=0.50)
     parser.add_argument("--max-discharge-mw", type=float, default=100.0)
     parser.add_argument("--max-charge-mw", type=float, default=100.0)
+    parser.add_argument("--temperature-c", type=float)
+    parser.add_argument("--temperature-derating-csv", type=Path)
     parser.add_argument("--previous-filtered-frequency-hz", type=float)
     parser.add_argument("--measurement-interval-seconds", type=float)
     parser.add_argument("--frequency-filter-time-constant-seconds", type=float)
@@ -425,6 +463,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         frequency_filter_config = FirstOrderFilterConfig(
             args.frequency_filter_time_constant_seconds
         )
+    temperature_inputs = (
+        args.temperature_c,
+        args.temperature_derating_csv,
+    )
+    if any(value is not None for value in temperature_inputs) and not all(
+        value is not None for value in temperature_inputs
+    ):
+        raise ValueError(
+            "temperature_c and temperature_derating_csv must be provided together"
+        )
+    temperature_derating_curve = None
+    if args.temperature_derating_csv is not None:
+        temperature_derating_curve = load_temperature_derating_csv(
+            args.temperature_derating_csv
+        )
     result = dispatch_frequency_watt(
         frequency_hz=args.frequency_hz,
         baseline_active_mw=args.baseline_active_mw,
@@ -441,6 +494,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         previous_filtered_frequency_hz=args.previous_filtered_frequency_hz,
         measurement_interval_seconds=args.measurement_interval_seconds,
         capability_envelope=capability_envelope,
+        temperature_c=args.temperature_c,
+        temperature_derating_curve=temperature_derating_curve,
     )
     capability = result.capability
     if isinstance(capability_envelope, DirectionalCapabilityEnvelope):
@@ -470,7 +525,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
     print(f"Droop adjustment: {result.droop_adjustment_mw:.3f} MW")
     print(f"Unconstrained active request: {result.unconstrained_active_mw:.3f} MW")
-    if result.ramp is not None or result.energy is not None:
+    if (
+        result.ramp is not None
+        or result.temperature_derating is not None
+        or result.energy is not None
+    ):
         print(f"Power-bounded active request: {result.power_bounded_active_mw:.3f} MW")
     if result.ramp is not None:
         direction = (
@@ -482,6 +541,32 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"Ramp-bounded active request: {result.ramp_bounded_active_mw:.3f} MW")
         print(f"Ramp limited: {str(result.ramp.ramp_limited).lower()}")
         print(f"Ramp limiting direction: {direction}")
+    if result.temperature_derating is not None:
+        temperature = result.temperature_derating
+        print(f"Temperature: {temperature.limits.temperature_c:.3f} C")
+        print(
+            "Sampled temperature discharge limit: "
+            f"{temperature.limits.max_discharge_mw:.3f} MW"
+        )
+        print(
+            "Sampled temperature charge limit: "
+            f"{temperature.limits.max_charge_mw:.3f} MW"
+        )
+        print(
+            "Effective temperature discharge limit: "
+            f"{temperature.effective_max_discharge_mw:.3f} MW"
+        )
+        print(
+            "Effective temperature charge limit: "
+            f"{temperature.effective_max_charge_mw:.3f} MW"
+        )
+        print(
+            "Temperature-bounded active request: "
+            f"{result.temperature_bounded_active_mw:.3f} MW"
+        )
+        print(
+            f"Temperature power limited: {str(temperature.temperature_limited).lower()}"
+        )
     print(f"Storage-bounded active request: {result.bounded_active_mw:.3f} MW")
     print(f"Storage power limited: {str(result.storage_power_limited).lower()}")
     if result.energy is not None:

--- a/models/grid_support_sequence.py
+++ b/models/grid_support_sequence.py
@@ -23,6 +23,10 @@ try:
         reactive_axis_limit_mvar,
     )
     from models.ramp_limits import RampRateLimits
+    from models.temperature_derating import (
+        TemperaturePowerDeratingCurve,
+        load_temperature_derating_csv,
+    )
     from models.volt_var import VoltVarCurve
 except ModuleNotFoundError:
     from energy_limits import StorageEnergyState
@@ -41,6 +45,10 @@ except ModuleNotFoundError:
         reactive_axis_limit_mvar,
     )
     from ramp_limits import RampRateLimits
+    from temperature_derating import (
+        TemperaturePowerDeratingCurve,
+        load_temperature_derating_csv,
+    )
     from volt_var import VoltVarCurve
 
 
@@ -54,6 +62,7 @@ class GridSupportInterval:
     duration_minutes: float
     reactive_request_pu: float
     requested_reactive_mvar: float
+    temperature_c: float | None
     initial_soc: float
     ending_soc: float
     dispatch: FrequencyWattDispatch
@@ -80,6 +89,7 @@ class GridSupportSequence:
     soc_balance_error: float
     limited_interval_count: int
     storage_power_limited_interval_count: int
+    temperature_limited_interval_count: int
     ramp_limited_interval_count: int
     energy_limited_interval_count: int
     capability_limited_interval_count: int
@@ -129,6 +139,8 @@ def simulate_grid_support_sequence(
     capability_envelope: (
         PiecewiseCapabilityCurve | DirectionalCapabilityEnvelope | None
     ) = None,
+    temperature_c: Sequence[float] | None = None,
+    temperature_derating_curve: TemperaturePowerDeratingCurve | None = None,
 ) -> GridSupportSequence:
     """Compose grid-support controls while carrying plant state between intervals."""
 
@@ -141,6 +153,21 @@ def simulate_grid_support_sequence(
     energy_state.validate()
     frequency_curve.validate()
     voltage_curve.validate()
+    if (temperature_c is None) != (temperature_derating_curve is None):
+        raise ValueError(
+            "temperature_c and temperature_derating_curve must be provided together"
+        )
+    temperatures: tuple[float | None, ...]
+    if temperature_c is None:
+        temperatures = (None,) * len(frequencies)
+    else:
+        supplied_temperatures = tuple(temperature_c)
+        if len(supplied_temperatures) != len(frequencies):
+            raise ValueError("temperature profile must match the other profile lengths")
+        for index, temperature in enumerate(supplied_temperatures):
+            if not math.isfinite(temperature):
+                raise ValueError(f"temperature_c[{index}] must be finite")
+        temperatures = supplied_temperatures
     if (apparent_power_limit_mva is None) == (capability_envelope is None):
         raise ValueError(
             "provide exactly one circular MVA limit or sampled capability envelope"
@@ -183,11 +210,12 @@ def simulate_grid_support_sequence(
     previous_active_mw = initial_active_mw
     previous_filtered_frequency_hz = initial_filtered_frequency_hz
     interval_results: list[GridSupportInterval] = []
-    for frequency, voltage, baseline, duration in zip(
+    for frequency, voltage, baseline, duration, temperature in zip(
         frequencies,
         voltages,
         baselines,
         durations,
+        temperatures,
         strict=True,
     ):
         request_pu = voltage_curve.reactive_request_pu(voltage)
@@ -215,6 +243,8 @@ def simulate_grid_support_sequence(
                 None if frequency_filter_config is None else duration * 60.0
             ),
             capability_envelope=capability_envelope,
+            temperature_c=temperature,
+            temperature_derating_curve=temperature_derating_curve,
         )
         assert dispatch.delivered_energy is not None
         delivered_energy = dispatch.delivered_energy
@@ -226,6 +256,7 @@ def simulate_grid_support_sequence(
                 duration_minutes=duration,
                 reactive_request_pu=request_pu,
                 requested_reactive_mvar=requested_reactive_mvar,
+                temperature_c=temperature,
                 initial_soc=delivered_energy.initial_soc,
                 ending_soc=delivered_energy.ending_soc,
                 dispatch=dispatch,
@@ -307,6 +338,10 @@ def simulate_grid_support_sequence(
         dispatch = interval.dispatch
         return (
             dispatch.storage_power_limited
+            or (
+                dispatch.temperature_derating is not None
+                and dispatch.temperature_derating.temperature_limited
+            )
             or (dispatch.ramp is not None and dispatch.ramp.ramp_limited)
             or (dispatch.energy is not None and dispatch.energy.energy_limited)
             or dispatch.capability.limited
@@ -331,6 +366,11 @@ def simulate_grid_support_sequence(
         limited_interval_count=sum(interval_is_limited(item) for item in intervals),
         storage_power_limited_interval_count=sum(
             item.dispatch.storage_power_limited for item in intervals
+        ),
+        temperature_limited_interval_count=sum(
+            item.dispatch.temperature_derating is not None
+            and item.dispatch.temperature_derating.temperature_limited
+            for item in intervals
         ),
         ramp_limited_interval_count=sum(
             item.dispatch.ramp is not None and item.dispatch.ramp.ramp_limited
@@ -402,6 +442,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--full-response-deviation-hz", type=float, default=0.50)
     parser.add_argument("--max-discharge-mw", type=float, default=100.0)
     parser.add_argument("--max-charge-mw", type=float, default=100.0)
+    parser.add_argument("--temperature-c-profile", type=_parse_number_series)
+    parser.add_argument("--temperature-derating-csv", type=Path)
     parser.add_argument("--low-saturation-pu", type=float, default=0.92)
     parser.add_argument("--low-deadband-pu", type=float, default=0.98)
     parser.add_argument("--high-deadband-pu", type=float, default=1.02)
@@ -422,6 +464,11 @@ def _limit_labels(interval: GridSupportInterval) -> str:
         labels.append("storage_power")
     if dispatch.ramp is not None and dispatch.ramp.ramp_limited:
         labels.append("ramp")
+    if (
+        dispatch.temperature_derating is not None
+        and dispatch.temperature_derating.temperature_limited
+    ):
+        labels.append("temperature")
     if dispatch.energy is not None and dispatch.energy.energy_limited:
         labels.append("energy")
     if dispatch.capability.limited:
@@ -480,6 +527,23 @@ def main(argv: Sequence[str] | None = None) -> int:
             args.frequency_filter_time_constant_seconds
         )
 
+    temperature_inputs = (
+        args.temperature_c_profile,
+        args.temperature_derating_csv,
+    )
+    if any(value is not None for value in temperature_inputs) and not all(
+        value is not None for value in temperature_inputs
+    ):
+        raise ValueError(
+            "temperature_c_profile and temperature_derating_csv "
+            "must be provided together"
+        )
+    temperature_derating_curve = None
+    if args.temperature_derating_csv is not None:
+        temperature_derating_curve = load_temperature_derating_csv(
+            args.temperature_derating_csv
+        )
+
     result = simulate_grid_support_sequence(
         frequency_hz=args.frequency_hz_profile,
         voltage_pu=args.voltage_pu_profile,
@@ -517,6 +581,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         frequency_filter_config=filter_config,
         initial_filtered_frequency_hz=args.initial_filtered_frequency_hz,
         capability_envelope=capability_envelope,
+        temperature_c=args.temperature_c_profile,
+        temperature_derating_curve=temperature_derating_curve,
     )
 
     if isinstance(capability_envelope, DirectionalCapabilityEnvelope):
@@ -533,6 +599,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"Capability model: circular limit ({args.limit_mva:.3f} MVA)")
     print(f"Intervals: {len(result.intervals)}")
     print(f"Limited intervals: {result.limited_interval_count}")
+    if temperature_derating_curve is not None:
+        print(
+            "Temperature derating model: piecewise curve "
+            f"({len(temperature_derating_curve.points)} points)"
+        )
+        print(
+            "Temperature-limited intervals: "
+            f"{result.temperature_limited_interval_count}"
+        )
     print(f"Total duration: {result.total_duration_minutes:.3f} minutes")
     print(f"Initial SOC: {result.initial_soc:.4f}")
     print(f"Ending SOC: {result.ending_soc:.4f}")
@@ -561,9 +636,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(f"SOC balance error: {result.soc_balance_error:.3e}")
     for index, interval in enumerate(result.intervals, start=1):
         dispatch = interval.dispatch
+        temperature_text = (
+            ""
+            if interval.temperature_c is None
+            else f"temperature={interval.temperature_c:.3f} C, "
+        )
         print(
             f"Interval {index}: frequency={interval.frequency_hz:.3f} Hz, "
             f"voltage={interval.voltage_pu:.3f} pu, "
+            f"{temperature_text}"
             f"requested_p={dispatch.unconstrained_active_mw:.3f} MW, "
             f"requested_q={interval.requested_reactive_mvar:.3f} MVAr, "
             f"delivered_p={dispatch.capability.active_mw:.3f} MW, "

--- a/models/temperature_derating.py
+++ b/models/temperature_derating.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class TemperaturePowerPoint:
+    """One externally supplied temperature and active-power limit sample."""
+
+    temperature_c: float
+    max_discharge_mw: float
+    max_charge_mw: float
+
+
+@dataclass(frozen=True)
+class InterpolatedTemperatureLimits:
+    """Auditable piecewise-linear limits at one operating temperature."""
+
+    temperature_c: float
+    lower_temperature_c: float
+    upper_temperature_c: float
+    interpolation_fraction: float
+    max_discharge_mw: float
+    max_charge_mw: float
+    endpoint_clamped: bool
+
+
+@dataclass(frozen=True)
+class TemperatureLimitedDispatch:
+    """Active-power request after nameplate and temperature limits."""
+
+    requested_active_mw: float
+    nameplate_bounded_active_mw: float
+    delivered_active_mw: float
+    nameplate_max_discharge_mw: float
+    nameplate_max_charge_mw: float
+    effective_max_discharge_mw: float
+    effective_max_charge_mw: float
+    nameplate_limited: bool
+    temperature_limited: bool
+    limits: InterpolatedTemperatureLimits
+
+
+@dataclass(frozen=True)
+class TemperaturePowerDeratingCurve:
+    """Strict sampled charge/discharge limits with linear interpolation."""
+
+    points: tuple[TemperaturePowerPoint, ...]
+
+    def __post_init__(self) -> None:
+        points = tuple(self.points)
+        object.__setattr__(self, "points", points)
+        if len(points) < 2:
+            raise ValueError(
+                "temperature derating curve must contain at least two points"
+            )
+
+        for index, point in enumerate(points):
+            values = {
+                f"points[{index}].temperature_c": point.temperature_c,
+                f"points[{index}].max_discharge_mw": point.max_discharge_mw,
+                f"points[{index}].max_charge_mw": point.max_charge_mw,
+            }
+            for name, value in values.items():
+                if not math.isfinite(value):
+                    raise ValueError(f"{name} must be finite")
+            if point.max_discharge_mw < 0.0 or point.max_charge_mw < 0.0:
+                raise ValueError("temperature power limits must be nonnegative")
+
+        for left, right in zip(points[:-1], points[1:], strict=True):
+            if right.temperature_c <= left.temperature_c:
+                raise ValueError("curve temperatures must be strictly increasing")
+
+    def limits_at(self, temperature_c: float) -> InterpolatedTemperatureLimits:
+        """Interpolate limits, clamping temperatures outside sampled endpoints."""
+
+        if not math.isfinite(temperature_c):
+            raise ValueError("temperature_c must be finite")
+
+        first = self.points[0]
+        last = self.points[-1]
+        if temperature_c <= first.temperature_c:
+            return InterpolatedTemperatureLimits(
+                temperature_c=temperature_c,
+                lower_temperature_c=first.temperature_c,
+                upper_temperature_c=first.temperature_c,
+                interpolation_fraction=0.0,
+                max_discharge_mw=first.max_discharge_mw,
+                max_charge_mw=first.max_charge_mw,
+                endpoint_clamped=temperature_c < first.temperature_c,
+            )
+        if temperature_c >= last.temperature_c:
+            return InterpolatedTemperatureLimits(
+                temperature_c=temperature_c,
+                lower_temperature_c=last.temperature_c,
+                upper_temperature_c=last.temperature_c,
+                interpolation_fraction=0.0,
+                max_discharge_mw=last.max_discharge_mw,
+                max_charge_mw=last.max_charge_mw,
+                endpoint_clamped=temperature_c > last.temperature_c,
+            )
+
+        for left, right in zip(self.points[:-1], self.points[1:], strict=True):
+            if temperature_c <= right.temperature_c:
+                fraction = (temperature_c - left.temperature_c) / (
+                    right.temperature_c - left.temperature_c
+                )
+                return InterpolatedTemperatureLimits(
+                    temperature_c=temperature_c,
+                    lower_temperature_c=left.temperature_c,
+                    upper_temperature_c=right.temperature_c,
+                    interpolation_fraction=fraction,
+                    max_discharge_mw=left.max_discharge_mw
+                    + fraction * (right.max_discharge_mw - left.max_discharge_mw),
+                    max_charge_mw=left.max_charge_mw
+                    + fraction * (right.max_charge_mw - left.max_charge_mw),
+                    endpoint_clamped=False,
+                )
+        raise RuntimeError("validated temperature curve did not cover temperature")
+
+
+def limit_active_power_by_temperature(
+    requested_active_mw: float,
+    temperature_c: float,
+    nameplate_max_discharge_mw: float,
+    nameplate_max_charge_mw: float,
+    curve: TemperaturePowerDeratingCurve,
+) -> TemperatureLimitedDispatch:
+    """Apply asymmetric nameplate and sampled temperature power limits."""
+
+    values = {
+        "requested_active_mw": requested_active_mw,
+        "nameplate_max_discharge_mw": nameplate_max_discharge_mw,
+        "nameplate_max_charge_mw": nameplate_max_charge_mw,
+    }
+    for name, value in values.items():
+        if not math.isfinite(value):
+            raise ValueError(f"{name} must be finite")
+    if nameplate_max_discharge_mw <= 0.0 or nameplate_max_charge_mw <= 0.0:
+        raise ValueError("nameplate charge and discharge limits must be positive")
+
+    limits = curve.limits_at(temperature_c)
+    nameplate_bounded_active_mw = max(
+        -nameplate_max_charge_mw,
+        min(nameplate_max_discharge_mw, requested_active_mw),
+    )
+    effective_max_discharge_mw = min(
+        nameplate_max_discharge_mw,
+        limits.max_discharge_mw,
+    )
+    effective_max_charge_mw = min(
+        nameplate_max_charge_mw,
+        limits.max_charge_mw,
+    )
+    delivered_active_mw = max(
+        -effective_max_charge_mw,
+        min(effective_max_discharge_mw, nameplate_bounded_active_mw),
+    )
+
+    def differs(left: float, right: float) -> bool:
+        return not math.isclose(left, right, rel_tol=0.0, abs_tol=1e-12)
+
+    return TemperatureLimitedDispatch(
+        requested_active_mw=requested_active_mw,
+        nameplate_bounded_active_mw=nameplate_bounded_active_mw,
+        delivered_active_mw=delivered_active_mw,
+        nameplate_max_discharge_mw=nameplate_max_discharge_mw,
+        nameplate_max_charge_mw=nameplate_max_charge_mw,
+        effective_max_discharge_mw=effective_max_discharge_mw,
+        effective_max_charge_mw=effective_max_charge_mw,
+        nameplate_limited=differs(requested_active_mw, nameplate_bounded_active_mw),
+        temperature_limited=differs(
+            nameplate_bounded_active_mw,
+            delivered_active_mw,
+        ),
+        limits=limits,
+    )
+
+
+def load_temperature_derating_csv(
+    path: str | Path,
+) -> TemperaturePowerDeratingCurve:
+    """Load a strict temperature-to-charge/discharge-limit CSV."""
+
+    csv_path = Path(path)
+    with csv_path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        expected_columns = (
+            "temperature_c",
+            "max_discharge_mw",
+            "max_charge_mw",
+        )
+        if tuple(reader.fieldnames or ()) != expected_columns:
+            raise ValueError(
+                "temperature derating CSV header must be "
+                "temperature_c,max_discharge_mw,max_charge_mw"
+            )
+        points: list[TemperaturePowerPoint] = []
+        for line_number, row in enumerate(reader, start=2):
+            if None in row or any(
+                value is None or not value.strip() for value in row.values()
+            ):
+                raise ValueError(
+                    f"temperature derating CSV line {line_number} must be complete"
+                )
+            try:
+                point = TemperaturePowerPoint(
+                    temperature_c=float(row["temperature_c"]),
+                    max_discharge_mw=float(row["max_discharge_mw"]),
+                    max_charge_mw=float(row["max_charge_mw"]),
+                )
+            except ValueError as error:
+                raise ValueError(
+                    f"temperature derating CSV line {line_number} must be numeric"
+                ) from error
+            points.append(point)
+    return TemperaturePowerDeratingCurve(tuple(points))
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Apply an external sampled temperature power envelope."
+    )
+    parser.add_argument("--active-mw", type=float, required=True)
+    parser.add_argument("--temperature-c", type=float, required=True)
+    parser.add_argument("--max-discharge-mw", type=float, required=True)
+    parser.add_argument("--max-charge-mw", type=float, required=True)
+    parser.add_argument("--curve-csv", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    curve = load_temperature_derating_csv(args.curve_csv)
+    result = limit_active_power_by_temperature(
+        args.active_mw,
+        args.temperature_c,
+        args.max_discharge_mw,
+        args.max_charge_mw,
+        curve,
+    )
+    limits = result.limits
+    print(f"Temperature: {limits.temperature_c:.3f} C")
+    print(f"Sampled discharge limit: {limits.max_discharge_mw:.3f} MW")
+    print(f"Sampled charge limit: {limits.max_charge_mw:.3f} MW")
+    print(f"Effective discharge limit: {result.effective_max_discharge_mw:.3f} MW")
+    print(f"Effective charge limit: {result.effective_max_charge_mw:.3f} MW")
+    print(f"Endpoint clamped: {str(limits.endpoint_clamped).lower()}")
+    print(f"Delivered active power: {result.delivered_active_mw:.3f} MW")
+    print(f"Temperature limited: {str(result.temperature_limited).lower()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_frequency_watt.py
+++ b/tests/test_frequency_watt.py
@@ -19,6 +19,7 @@ from models.pq_capability import (
     load_directional_capability_csv,
 )
 from models.ramp_limits import RampDirection, RampRateLimits
+from models.temperature_derating import load_temperature_derating_csv
 
 
 class FrequencyWattTests(unittest.TestCase):
@@ -114,6 +115,95 @@ class FrequencyWattTests(unittest.TestCase):
         self.assertAlmostEqual(result.bounded_active_mw, 100.0)
         self.assertTrue(result.storage_power_limited)
         self.assertFalse(result.capability.limited)
+
+    def test_temperature_curve_hard_limits_discharge_after_power_bound(self):
+        temperature_curve = load_temperature_derating_csv(
+            self.data_directory / "illustrative_temperature_derating.csv"
+        )
+
+        result = dispatch_frequency_watt(
+            49.5,
+            0.0,
+            0.0,
+            120.0,
+            temperature_c=45.0,
+            temperature_derating_curve=temperature_curve,
+        )
+
+        self.assertEqual(result.power_bounded_active_mw, 100.0)
+        self.assertEqual(result.ramp_bounded_active_mw, 100.0)
+        self.assertEqual(result.temperature_bounded_active_mw, 70.0)
+        self.assertEqual(result.bounded_active_mw, 70.0)
+        self.assertFalse(result.storage_power_limited)
+        self.assertIsNotNone(result.temperature_derating)
+        assert result.temperature_derating is not None
+        self.assertTrue(result.temperature_derating.temperature_limited)
+        self.assertEqual(result.capability.active_mw, 70.0)
+
+    def test_temperature_limit_takes_precedence_over_slow_ramp_down(self):
+        temperature_curve = load_temperature_derating_csv(
+            self.data_directory / "illustrative_temperature_derating.csv"
+        )
+
+        result = dispatch_frequency_watt(
+            50.0,
+            0.0,
+            0.0,
+            150.0,
+            ramp_limits=RampRateLimits(10.0, 10.0),
+            previous_active_mw=100.0,
+            ramp_interval_seconds=60.0,
+            temperature_c=55.0,
+            temperature_derating_curve=temperature_curve,
+        )
+
+        self.assertEqual(result.power_bounded_active_mw, 0.0)
+        self.assertEqual(result.ramp_bounded_active_mw, 90.0)
+        self.assertEqual(result.temperature_bounded_active_mw, 20.0)
+        assert result.ramp is not None
+        assert result.temperature_derating is not None
+        self.assertTrue(result.ramp.ramp_limited)
+        self.assertTrue(result.temperature_derating.temperature_limited)
+
+    def test_temperature_curve_applies_independent_charge_limit(self):
+        temperature_curve = load_temperature_derating_csv(
+            self.data_directory / "illustrative_temperature_derating.csv"
+        )
+
+        result = dispatch_frequency_watt(
+            50.5,
+            0.0,
+            0.0,
+            120.0,
+            temperature_c=45.0,
+            temperature_derating_curve=temperature_curve,
+        )
+
+        self.assertEqual(result.temperature_bounded_active_mw, -50.0)
+        assert result.temperature_derating is not None
+        self.assertEqual(result.temperature_derating.effective_max_charge_mw, 50.0)
+        self.assertTrue(result.temperature_derating.temperature_limited)
+
+    def test_temperature_configuration_is_paired(self):
+        temperature_curve = load_temperature_derating_csv(
+            self.data_directory / "illustrative_temperature_derating.csv"
+        )
+        with self.assertRaisesRegex(ValueError, "must be provided together"):
+            dispatch_frequency_watt(
+                50.0,
+                0.0,
+                0.0,
+                100.0,
+                temperature_c=25.0,
+            )
+        with self.assertRaisesRegex(ValueError, "must be provided together"):
+            dispatch_frequency_watt(
+                50.0,
+                0.0,
+                0.0,
+                100.0,
+                temperature_derating_curve=temperature_curve,
+            )
 
     def test_active_priority_preserves_frequency_support(self):
         result = dispatch_frequency_watt(49.725, 20.0, 80.0, 100.0)
@@ -376,6 +466,41 @@ class FrequencyWattTests(unittest.TestCase):
         self.assertIn("Droop adjustment: 50.000 MW", output)
         self.assertIn("Capability limited: true", output)
         self.assertIn("Delivered active power: 70.000 MW", output)
+
+    def test_cli_reports_temperature_derating_stage(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--frequency-hz",
+                    "49.5",
+                    "--limit-mva",
+                    "120",
+                    "--temperature-c",
+                    "45",
+                    "--temperature-derating-csv",
+                    str(self.data_directory / "illustrative_temperature_derating.csv"),
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Sampled temperature discharge limit: 70.000 MW", output)
+        self.assertIn("Temperature-bounded active request: 70.000 MW", output)
+        self.assertIn("Temperature power limited: true", output)
+
+    def test_cli_rejects_partial_temperature_configuration(self):
+        with self.assertRaisesRegex(ValueError, "must be provided together"):
+            main(
+                [
+                    "--frequency-hz",
+                    "49.5",
+                    "--limit-mva",
+                    "100",
+                    "--temperature-c",
+                    "45",
+                ]
+            )
 
     def test_cli_reports_soc_limited_frequency_response(self):
         standard_output = io.StringIO()

--- a/tests/test_grid_support_sequence.py
+++ b/tests/test_grid_support_sequence.py
@@ -16,6 +16,7 @@ from models.pq_capability import (
     load_directional_capability_csv,
 )
 from models.ramp_limits import RampRateLimits
+from models.temperature_derating import load_temperature_derating_csv
 from models.volt_var import VoltVarCurve
 
 
@@ -267,6 +268,39 @@ class GridSupportSequenceTests(unittest.TestCase):
         )
         self.assertAlmostEqual(result.soc_balance_error, 0.0)
 
+    def test_temperature_profile_applies_and_counts_hard_power_limits(self):
+        temperature_curve = load_temperature_derating_csv(
+            self.data_directory / "illustrative_temperature_derating.csv"
+        )
+
+        result = simulate_grid_support_sequence(
+            (49.5, 49.5, 49.5),
+            (1.0, 1.0, 1.0),
+            (0.0, 0.0, 0.0),
+            (1.0, 1.0, 1.0),
+            StorageEnergyState(
+                1000.0,
+                0.50,
+                charge_efficiency=1.0,
+                discharge_efficiency=1.0,
+            ),
+            150.0,
+            temperature_c=(-20.0, 20.0, 55.0),
+            temperature_derating_curve=temperature_curve,
+        )
+
+        delivered = tuple(
+            interval.dispatch.capability.active_mw for interval in result.intervals
+        )
+        self.assertEqual(delivered, (30.0, 100.0, 20.0))
+        self.assertEqual(
+            tuple(interval.temperature_c for interval in result.intervals),
+            (-20.0, 20.0, 55.0),
+        )
+        self.assertEqual(result.temperature_limited_interval_count, 2)
+        self.assertEqual(result.limited_interval_count, 2)
+        self.assertAlmostEqual(result.ending_soc, 0.4975)
+
     def test_profile_and_optional_state_inputs_are_validated(self):
         state = StorageEnergyState(100.0, 0.50)
         with self.assertRaisesRegex(ValueError, "at least one interval"):
@@ -303,6 +337,30 @@ class GridSupportSequenceTests(unittest.TestCase):
                 state,
                 100.0,
                 initial_filtered_frequency_hz=50.0,
+            )
+        temperature_curve = load_temperature_derating_csv(
+            self.data_directory / "illustrative_temperature_derating.csv"
+        )
+        with self.assertRaisesRegex(ValueError, "must be provided together"):
+            simulate_grid_support_sequence(
+                (50.0,),
+                (1.0,),
+                (0.0,),
+                (1.0,),
+                state,
+                100.0,
+                temperature_c=(25.0,),
+            )
+        with self.assertRaisesRegex(ValueError, "must match"):
+            simulate_grid_support_sequence(
+                (50.0,),
+                (1.0,),
+                (0.0,),
+                (1.0,),
+                state,
+                100.0,
+                temperature_c=(25.0, 30.0),
+                temperature_derating_curve=temperature_curve,
             )
         curve = load_capability_curve_csv(
             self.data_directory / "illustrative_capability_curve.csv"
@@ -398,6 +456,58 @@ class GridSupportSequenceTests(unittest.TestCase):
             output,
         )
         self.assertIn("limits=storage_power,capability", output)
+
+    def test_cli_reports_temperature_profile_limits(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--frequency-hz-profile",
+                    "49.5,49.5",
+                    "--voltage-pu-profile",
+                    "1,1",
+                    "--duration-minutes-profile",
+                    "1,1",
+                    "--limit-mva",
+                    "150",
+                    "--energy-capacity-mwh",
+                    "1000",
+                    "--initial-soc",
+                    "0.5",
+                    "--temperature-c-profile",
+                    "20,55",
+                    "--temperature-derating-csv",
+                    str(self.data_directory / "illustrative_temperature_derating.csv"),
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Temperature derating model: piecewise curve (6 points)", output)
+        self.assertIn("Temperature-limited intervals: 1", output)
+        self.assertIn("temperature=55.000 C", output)
+        self.assertIn("limits=temperature", output)
+
+    def test_cli_rejects_partial_temperature_profile_configuration(self):
+        with self.assertRaisesRegex(ValueError, "must be provided together"):
+            main(
+                [
+                    "--frequency-hz-profile",
+                    "50",
+                    "--voltage-pu-profile",
+                    "1",
+                    "--duration-minutes-profile",
+                    "1",
+                    "--limit-mva",
+                    "100",
+                    "--energy-capacity-mwh",
+                    "100",
+                    "--initial-soc",
+                    "0.5",
+                    "--temperature-c-profile",
+                    "25",
+                ]
+            )
 
     def test_cli_reports_grid_support_storage_losses(self):
         standard_output = io.StringIO()

--- a/tests/test_temperature_derating.py
+++ b/tests/test_temperature_derating.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import math
+import tempfile
+import unittest
+from pathlib import Path
+
+from models.temperature_derating import (
+    TemperaturePowerDeratingCurve,
+    TemperaturePowerPoint,
+    limit_active_power_by_temperature,
+    load_temperature_derating_csv,
+    main,
+)
+
+
+class TemperatureDeratingTests(unittest.TestCase):
+    data_file = (
+        Path(__file__).parents[1]
+        / "models"
+        / "data"
+        / "illustrative_temperature_derating.csv"
+    )
+
+    def test_curve_interpolates_charge_and_discharge_limits(self):
+        curve = load_temperature_derating_csv(self.data_file)
+
+        limits = curve.limits_at(40.0)
+
+        self.assertEqual(limits.lower_temperature_c, 35.0)
+        self.assertEqual(limits.upper_temperature_c, 45.0)
+        self.assertEqual(limits.interpolation_fraction, 0.5)
+        self.assertEqual(limits.max_discharge_mw, 85.0)
+        self.assertEqual(limits.max_charge_mw, 65.0)
+        self.assertFalse(limits.endpoint_clamped)
+
+    def test_curve_clamps_outside_sampled_temperature_range(self):
+        curve = load_temperature_derating_csv(self.data_file)
+
+        cold = curve.limits_at(-30.0)
+        hot = curve.limits_at(70.0)
+
+        self.assertEqual((cold.max_discharge_mw, cold.max_charge_mw), (30.0, 0.0))
+        self.assertEqual((hot.max_discharge_mw, hot.max_charge_mw), (20.0, 10.0))
+        self.assertTrue(cold.endpoint_clamped)
+        self.assertTrue(hot.endpoint_clamped)
+
+    def test_dispatch_applies_asymmetric_temperature_and_nameplate_limits(self):
+        curve = load_temperature_derating_csv(self.data_file)
+
+        discharge = limit_active_power_by_temperature(90.0, 40.0, 80.0, 100.0, curve)
+        charge = limit_active_power_by_temperature(-90.0, 40.0, 80.0, 100.0, curve)
+
+        self.assertEqual(discharge.delivered_active_mw, 80.0)
+        self.assertTrue(discharge.nameplate_limited)
+        self.assertFalse(discharge.temperature_limited)
+        self.assertEqual(discharge.effective_max_discharge_mw, 80.0)
+        self.assertEqual(charge.delivered_active_mw, -65.0)
+        self.assertFalse(charge.nameplate_limited)
+        self.assertTrue(charge.temperature_limited)
+        self.assertEqual(charge.effective_max_charge_mw, 65.0)
+
+    def test_curve_rejects_invalid_points_and_temperature(self):
+        point = TemperaturePowerPoint(20.0, 100.0, 80.0)
+        with self.assertRaisesRegex(ValueError, "at least two"):
+            TemperaturePowerDeratingCurve((point,))
+        with self.assertRaisesRegex(ValueError, "strictly increasing"):
+            TemperaturePowerDeratingCurve((point, point))
+        with self.assertRaisesRegex(ValueError, "nonnegative"):
+            TemperaturePowerDeratingCurve(
+                (point, TemperaturePowerPoint(30.0, -1.0, 50.0))
+            )
+        curve = TemperaturePowerDeratingCurve(
+            (point, TemperaturePowerPoint(30.0, 90.0, 70.0))
+        )
+        with self.assertRaisesRegex(ValueError, "temperature_c must be finite"):
+            curve.limits_at(math.nan)
+
+    def test_csv_loader_requires_exact_complete_numeric_schema(self):
+        cases = (
+            ("temperature_c,max_discharge_mw\n20,100\n", "header must be"),
+            (
+                "temperature_c,max_discharge_mw,max_charge_mw\n20,100,\n",
+                "must be complete",
+            ),
+            (
+                "temperature_c,max_discharge_mw,max_charge_mw\n20,high,80\n",
+                "must be numeric",
+            ),
+        )
+        for content, message in cases:
+            with self.subTest(message=message), tempfile.TemporaryDirectory() as folder:
+                path = Path(folder) / "curve.csv"
+                path.write_text(content, encoding="utf-8")
+                with self.assertRaisesRegex(ValueError, message):
+                    load_temperature_derating_csv(path)
+
+    def test_cli_reports_interpolated_and_effective_limits(self):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            exit_code = main(
+                [
+                    "--active-mw",
+                    "-90",
+                    "--temperature-c",
+                    "40",
+                    "--max-discharge-mw",
+                    "80",
+                    "--max-charge-mw",
+                    "100",
+                    "--curve-csv",
+                    str(self.data_file),
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        report = output.getvalue()
+        self.assertIn("Sampled discharge limit: 85.000 MW", report)
+        self.assertIn("Effective discharge limit: 80.000 MW", report)
+        self.assertIn("Delivered active power: -65.000 MW", report)
+        self.assertIn("Temperature limited: true", report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a strict external temperature-to-charge/discharge power envelope with linear interpolation and endpoint clamping
- compose the hard temperature limit into frequency-watt dispatch and stateful grid-support sequences
- preserve sampled, effective, and delivered limits in audit output, with illustrative data and documentation

## Validation

- python -m unittest discover -s tests -v (128 tests)
- uff check .
- uff format --check .
- python -m compileall -q models tests
- prettier --check .github/workflows/markdown-maintenance.yml README.md models/README.md
- independent oracle: 25,000 random interpolation/dispatch cases and 5,000 sequences (37,726 intervals), with 0 MW maximum power error and 4.441e-16 maximum SOC error
- canonical standalone, frequency-watt, and grid-support temperature-derating CLI runs