### PR TITLE
Add dispatch energy throughput accounting

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -42,6 +42,15 @@ jobs:
           --energy-capacity-mwh 100 --initial-soc 0.8
           --auxiliary-load-mw 2 --self-discharge-rate-per-hour 0.01
 
+      - name: Run energy throughput reference
+        run: >-
+          python models/energy_sequence.py
+          --active-mw-profile 50,50,50,-40
+          --duration-minutes-profile 15,15,15,30
+          --energy-capacity-mwh 100 --initial-soc 0.5
+          --minimum-soc 0.2 --charge-efficiency 0.8
+          --discharge-efficiency 1
+
       - name: Run sampled capability envelope
         run: >-
           python models/pq_capability.py

--- a/README.md
+++ b/README.md
@@ -161,7 +161,10 @@ python -m unittest discover -s tests -v
 ```
 
 Review the [model assumptions and limitations](models/README.md) before mapping
-the result to a plant controller, PCS capability curve, or grid-code study.
+the result to a plant controller, PCS capability curve, grid-code study, or
+battery warranty. The multi-interval energy reference reports separate AC and
+stored-energy throughput, conversion loss, and throughput-equivalent full
+cycles without claiming a degradation model.
 
 ## Contribution Entry Points
 

--- a/models/README.md
+++ b/models/README.md
@@ -485,6 +485,10 @@ Ending SOC: 0.3600
 Requested AC energy: 17.500 MWh
 Delivered AC energy: 10.000 MWh
 Curtailed AC energy: 7.500 MWh
+AC energy throughput: 50.000 MWh
+Stored energy throughput: 46.000 MWh
+Conversion loss: 4.000 MWh
+Throughput-equivalent full cycles: 0.230000
 Stored energy change: -14.000 MWh
 ```
 
@@ -493,11 +497,29 @@ charging. Curtailed energy is the absolute requested-versus-delivered gap, so
 it remains nonnegative in either direction. `soc_balance_error` independently
 reconstructs final SOC from cumulative stored-energy change.
 
+The sequence also separates positive discharge and charge magnitudes on the AC
+and stored-energy sides. AC throughput is their AC-side sum. Stored-energy
+throughput is the sum of battery-side dispatch discharge and charge after the
+configured conversion efficiencies. Conversion loss closes the independent
+identity:
+
+```text
+net delivered AC energy + dispatch stored-energy change + conversion loss = 0
+```
+
+`throughput_equivalent_full_cycles` divides stored-energy throughput by twice
+the nominal energy capacity. One full discharge plus one full recharge is
+therefore one throughput-equivalent cycle. Auxiliary demand and self-discharge
+remain separately reported standing losses and do not increase this dispatch
+throughput metric.
+
 This is a forward audit of a supplied power trajectory, not a scheduler or
 optimizer. It does not choose prices, services, or interval requests, and it
 does not compose frequency, ramp, or P-Q constraints across time. The constant
 loss assumptions and nonlinear-efficiency, degradation, thermal, and capacity
-limitations of the single-interval model still apply.
+limitations of the single-interval model still apply. The equivalent-cycle
+value is an accounting normalization, not a rainflow cycle count, degradation
+estimate, warranty interpretation, or remaining-life prediction.
 
 ## Multi-Service Grid-Support Sequence
 

--- a/models/energy_limits.py
+++ b/models/energy_limits.py
@@ -178,7 +178,13 @@ def limit_active_power_by_energy(
         if self_discharge_energy_mwh < -1e-12:
             raise RuntimeError("self-discharge energy must be nonnegative")
         self_discharge_energy_mwh = max(0.0, self_discharge_energy_mwh)
-    ending_soc = ending_energy_mwh / state.energy_capacity_mwh
+    ending_soc = min(
+        state.maximum_soc,
+        max(
+            state.minimum_soc,
+            ending_energy_mwh / state.energy_capacity_mwh,
+        ),
+    )
     energy_limited = not math.isclose(
         delivered_active_mw,
         requested_active_mw,

--- a/models/energy_sequence.py
+++ b/models/energy_sequence.py
@@ -30,6 +30,15 @@ class EnergyDispatchSequence:
     requested_ac_energy_mwh: float
     delivered_ac_energy_mwh: float
     curtailed_ac_energy_mwh: float
+    delivered_discharge_ac_energy_mwh: float
+    delivered_charge_ac_energy_mwh: float
+    ac_energy_throughput_mwh: float
+    stored_discharge_energy_mwh: float
+    stored_charge_energy_mwh: float
+    stored_energy_throughput_mwh: float
+    conversion_loss_mwh: float
+    throughput_equivalent_full_cycles: float
+    conversion_balance_error_mwh: float
     dispatch_stored_energy_change_mwh: float
     auxiliary_energy_mwh: float
     self_discharge_energy_mwh: float
@@ -88,8 +97,51 @@ def simulate_energy_dispatch_sequence(
         / 60.0
         for interval in intervals
     )
+    delivered_discharge_ac_energy_mwh = math.fsum(
+        max(interval.delivered_active_mw, 0.0)
+        * interval.duration_minutes
+        / 60.0
+        for interval in intervals
+    )
+    delivered_charge_ac_energy_mwh = math.fsum(
+        max(-interval.delivered_active_mw, 0.0)
+        * interval.duration_minutes
+        / 60.0
+        for interval in intervals
+    )
+    ac_energy_throughput_mwh = (
+        delivered_discharge_ac_energy_mwh + delivered_charge_ac_energy_mwh
+    )
     dispatch_stored_energy_change_mwh = math.fsum(
         interval.dispatch_stored_energy_change_mwh for interval in intervals
+    )
+    stored_discharge_energy_mwh = math.fsum(
+        max(-interval.dispatch_stored_energy_change_mwh, 0.0)
+        for interval in intervals
+    )
+    stored_charge_energy_mwh = math.fsum(
+        max(interval.dispatch_stored_energy_change_mwh, 0.0)
+        for interval in intervals
+    )
+    stored_energy_throughput_mwh = (
+        stored_discharge_energy_mwh + stored_charge_energy_mwh
+    )
+    conversion_loss_mwh = (
+        stored_discharge_energy_mwh
+        - delivered_discharge_ac_energy_mwh
+        + delivered_charge_ac_energy_mwh
+        - stored_charge_energy_mwh
+    )
+    if conversion_loss_mwh < -1e-12:
+        raise RuntimeError("conversion loss must be nonnegative")
+    conversion_loss_mwh = max(0.0, conversion_loss_mwh)
+    throughput_equivalent_full_cycles = (
+        stored_energy_throughput_mwh / (2.0 * state.energy_capacity_mwh)
+    )
+    conversion_balance_error_mwh = (
+        delivered_ac_energy_mwh
+        + dispatch_stored_energy_change_mwh
+        + conversion_loss_mwh
     )
     auxiliary_energy_mwh = math.fsum(
         interval.auxiliary_energy_mwh for interval in intervals
@@ -113,6 +165,15 @@ def simulate_energy_dispatch_sequence(
         requested_ac_energy_mwh=requested_ac_energy_mwh,
         delivered_ac_energy_mwh=delivered_ac_energy_mwh,
         curtailed_ac_energy_mwh=curtailed_ac_energy_mwh,
+        delivered_discharge_ac_energy_mwh=delivered_discharge_ac_energy_mwh,
+        delivered_charge_ac_energy_mwh=delivered_charge_ac_energy_mwh,
+        ac_energy_throughput_mwh=ac_energy_throughput_mwh,
+        stored_discharge_energy_mwh=stored_discharge_energy_mwh,
+        stored_charge_energy_mwh=stored_charge_energy_mwh,
+        stored_energy_throughput_mwh=stored_energy_throughput_mwh,
+        conversion_loss_mwh=conversion_loss_mwh,
+        throughput_equivalent_full_cycles=throughput_equivalent_full_cycles,
+        conversion_balance_error_mwh=conversion_balance_error_mwh,
         dispatch_stored_energy_change_mwh=dispatch_stored_energy_change_mwh,
         auxiliary_energy_mwh=auxiliary_energy_mwh,
         self_discharge_energy_mwh=self_discharge_energy_mwh,
@@ -190,6 +251,30 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(f"Requested AC energy: {result.requested_ac_energy_mwh:.3f} MWh")
     print(f"Delivered AC energy: {result.delivered_ac_energy_mwh:.3f} MWh")
     print(f"Curtailed AC energy: {result.curtailed_ac_energy_mwh:.3f} MWh")
+    print(
+        "Delivered discharge/charge energy: "
+        f"{result.delivered_discharge_ac_energy_mwh:.3f} / "
+        f"{result.delivered_charge_ac_energy_mwh:.3f} MWh"
+    )
+    print(f"AC energy throughput: {result.ac_energy_throughput_mwh:.3f} MWh")
+    print(
+        "Stored discharge/charge energy: "
+        f"{result.stored_discharge_energy_mwh:.3f} / "
+        f"{result.stored_charge_energy_mwh:.3f} MWh"
+    )
+    print(
+        "Stored energy throughput: "
+        f"{result.stored_energy_throughput_mwh:.3f} MWh"
+    )
+    print(f"Conversion loss: {result.conversion_loss_mwh:.3f} MWh")
+    print(
+        "Throughput-equivalent full cycles: "
+        f"{result.throughput_equivalent_full_cycles:.6f}"
+    )
+    print(
+        "Conversion balance error: "
+        f"{result.conversion_balance_error_mwh:.3e} MWh"
+    )
     print(
         "Dispatch stored-energy change: "
         f"{result.dispatch_stored_energy_change_mwh:.3f} MWh"

--- a/tests/test_energy_sequence.py
+++ b/tests/test_energy_sequence.py
@@ -36,6 +36,15 @@ class EnergySequenceTests(unittest.TestCase):
         self.assertAlmostEqual(result.requested_ac_energy_mwh, 17.5)
         self.assertAlmostEqual(result.delivered_ac_energy_mwh, 10.0)
         self.assertAlmostEqual(result.curtailed_ac_energy_mwh, 7.5)
+        self.assertAlmostEqual(result.delivered_discharge_ac_energy_mwh, 30.0)
+        self.assertAlmostEqual(result.delivered_charge_ac_energy_mwh, 20.0)
+        self.assertAlmostEqual(result.ac_energy_throughput_mwh, 50.0)
+        self.assertAlmostEqual(result.stored_discharge_energy_mwh, 30.0)
+        self.assertAlmostEqual(result.stored_charge_energy_mwh, 16.0)
+        self.assertAlmostEqual(result.stored_energy_throughput_mwh, 46.0)
+        self.assertAlmostEqual(result.conversion_loss_mwh, 4.0)
+        self.assertAlmostEqual(result.throughput_equivalent_full_cycles, 0.23)
+        self.assertAlmostEqual(result.conversion_balance_error_mwh, 0.0)
         self.assertAlmostEqual(result.stored_energy_change_mwh, -14.0)
         self.assertAlmostEqual(result.ending_soc, 0.36)
         self.assertAlmostEqual(result.soc_balance_error, 0.0)
@@ -53,6 +62,24 @@ class EnergySequenceTests(unittest.TestCase):
         self.assertEqual(result.intervals, (expected,))
         self.assertEqual(result.initial_soc, state.initial_soc)
         self.assertEqual(result.ending_soc, expected.ending_soc)
+
+    def test_soc_boundary_roundoff_does_not_break_the_next_interval(self):
+        state = StorageEnergyState(
+            energy_capacity_mwh=0.1,
+            initial_soc=0.50,
+            minimum_soc=0.10,
+            maximum_soc=0.75,
+            charge_efficiency=1.0,
+        )
+        result = simulate_energy_dispatch_sequence(
+            (-1.0, 0.0),
+            (60.0, 1.0),
+            state,
+        )
+
+        self.assertEqual(result.intervals[0].ending_soc, state.maximum_soc)
+        self.assertEqual(result.intervals[1].initial_soc, state.maximum_soc)
+        self.assertLessEqual(result.ending_soc, state.maximum_soc)
 
     def test_split_idle_intervals_match_one_exact_loss_interval(self):
         state = StorageEnergyState(
@@ -75,6 +102,35 @@ class EnergySequenceTests(unittest.TestCase):
             combined.self_discharge_energy_mwh,
         )
         self.assertEqual(split.dispatch_stored_energy_change_mwh, 0.0)
+        self.assertEqual(split.ac_energy_throughput_mwh, 0.0)
+        self.assertEqual(split.stored_energy_throughput_mwh, 0.0)
+        self.assertEqual(split.conversion_loss_mwh, 0.0)
+        self.assertEqual(split.throughput_equivalent_full_cycles, 0.0)
+
+    def test_asymmetric_efficiencies_close_conversion_and_throughput_balances(self):
+        result = simulate_energy_dispatch_sequence(
+            (18.0, -20.0),
+            (60.0, 60.0),
+            StorageEnergyState(
+                100.0,
+                0.50,
+                minimum_soc=0.0,
+                maximum_soc=1.0,
+                charge_efficiency=0.80,
+                discharge_efficiency=0.90,
+            ),
+        )
+
+        self.assertAlmostEqual(result.delivered_discharge_ac_energy_mwh, 18.0)
+        self.assertAlmostEqual(result.delivered_charge_ac_energy_mwh, 20.0)
+        self.assertAlmostEqual(result.ac_energy_throughput_mwh, 38.0)
+        self.assertAlmostEqual(result.stored_discharge_energy_mwh, 20.0)
+        self.assertAlmostEqual(result.stored_charge_energy_mwh, 16.0)
+        self.assertAlmostEqual(result.stored_energy_throughput_mwh, 36.0)
+        self.assertAlmostEqual(result.conversion_loss_mwh, 6.0)
+        self.assertAlmostEqual(result.throughput_equivalent_full_cycles, 0.18)
+        self.assertAlmostEqual(result.conversion_balance_error_mwh, 0.0)
+        self.assertAlmostEqual(result.ending_soc, 0.46)
 
     def test_sequence_loss_aggregates_close_energy_identity(self):
         result = simulate_energy_dispatch_sequence(
@@ -201,6 +257,11 @@ class EnergySequenceTests(unittest.TestCase):
         self.assertIn("Ending SOC: 0.3600", output)
         self.assertIn("Delivered AC energy: 10.000 MWh", output)
         self.assertIn("Curtailed AC energy: 7.500 MWh", output)
+        self.assertIn("AC energy throughput: 50.000 MWh", output)
+        self.assertIn("Stored energy throughput: 46.000 MWh", output)
+        self.assertIn("Conversion loss: 4.000 MWh", output)
+        self.assertIn("Throughput-equivalent full cycles: 0.230000", output)
+        self.assertIn("Conversion balance error: 0.000e+00 MWh", output)
         self.assertIn(
             "Interval 3: requested=50.000 MW, delivered=20.000 MW",
             output,


### PR DESCRIPTION
## Summary
- report separate AC and stored-energy discharge, charge, and total throughput
- calculate conversion loss, an independent conversion-balance error, and throughput-equivalent full cycles
- keep auxiliary and self-discharge losses outside dispatch throughput
- clamp reported SOC to enforced bounds so one-ulp boundary roundoff cannot invalidate a later interval
- document the accounting definition and its degradation/warranty limitations

## Validation
- `python -m unittest discover -s tests -v` (130 passed)
- Python compilation for all model and test modules
- every executable command in `.github/workflows/markdown-maintenance.yml`
- `git diff --check`
- reference profile: 50 MWh AC throughput, 46 MWh stored throughput, 4 MWh conversion loss, 0.23 throughput-equivalent cycles
- Decimal oracle: 2,000 randomized trajectories / 9,056 intervals / 6,535 limited intervals
- maximum Decimal differences: 2.086e-13 MWh conversion loss, 2.195e-13 MWh stored throughput, 6.151e-16 equivalent cycles