### PR TITLE
Add sustained reserve headroom model

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -51,6 +51,15 @@ jobs:
           --minimum-soc 0.2 --charge-efficiency 0.8
           --discharge-efficiency 1
 
+      - name: Run sustained reserve headroom reference
+        run: >-
+          python models/reserve_headroom.py
+          --baseline-active-mw 10 --duration-minutes 30
+          --maximum-discharge-mw 100 --maximum-charge-mw 100
+          --energy-capacity-mwh 100 --initial-soc 0.5
+          --minimum-soc 0.2 --maximum-soc 0.8
+          --charge-efficiency 1 --discharge-efficiency 1
+
       - name: Run sampled capability envelope
         run: >-
           python models/pq_capability.py

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ python models/energy_sequence.py `
   --energy-capacity-mwh 100 --initial-soc 0.50 `
   --minimum-soc 0.20 --charge-efficiency 0.80 `
   --discharge-efficiency 1.00
+python models/reserve_headroom.py `
+  --baseline-active-mw 10 --duration-minutes 30 `
+  --maximum-discharge-mw 100 --maximum-charge-mw 100 `
+  --energy-capacity-mwh 100 --initial-soc 0.50 `
+  --minimum-soc 0.20 --maximum-soc 0.80 `
+  --charge-efficiency 1 --discharge-efficiency 1
 python models/grid_support_sequence.py `
   --frequency-hz-profile 50,49.5,50.5 `
   --voltage-pu-profile 1,0.92,1.08 `

--- a/models/README.md
+++ b/models/README.md
@@ -521,6 +521,47 @@ limitations of the single-interval model still apply. The equivalent-cycle
 value is an accounting normalization, not a rainflow cycle count, degradation
 estimate, warranty interpretation, or remaining-life prediction.
 
+## Sustained Reserve Headroom
+
+[`reserve_headroom.py`](reserve_headroom.py) converts nameplate charge and
+discharge limits into sustained upward and downward active-power reserve around
+a feasible baseline. It evaluates the configured response duration through the
+same SOC and standing-loss limiter, so a result distinguishes a power-limited
+reserve from one constrained by stored-energy headroom.
+
+Run a 30-minute assessment around a 10 MW discharge baseline:
+
+```powershell
+python models/reserve_headroom.py `
+  --baseline-active-mw 10 --duration-minutes 30 `
+  --maximum-discharge-mw 100 --maximum-charge-mw 100 `
+  --energy-capacity-mwh 100 --initial-soc 0.50 `
+  --minimum-soc 0.20 --maximum-soc 0.80 `
+  --charge-efficiency 1 --discharge-efficiency 1
+```
+
+Expected directional headroom:
+
+```text
+Upward active-power limit: 60.000 MW
+Downward active-power limit: -60.000 MW
+Upward reserve: 50.000 MW
+Downward reserve: 70.000 MW
+Upward energy limited: true
+Downward energy limited: true
+```
+
+Positive power is discharge and negative power is charge. Upward reserve is
+the sustained discharge limit minus the baseline. Downward reserve is the
+baseline minus the sustained charge limit, so a discharging baseline can have
+more downward headroom than the charge limit magnitude alone.
+
+The baseline must itself remain feasible for the full response duration. This
+reference evaluates replacement setpoints from the initial state; it does not
+model activation delay, ramping, P-Q competition, thermal derating, reserve
+recovery, simultaneous services, or probabilistic availability. Compose those
+constraints separately before making a market or grid-code claim.
+
 ## Multi-Service Grid-Support Sequence
 
 [`grid_support_sequence.py`](grid_support_sequence.py) composes the existing

--- a/models/reserve_headroom.py
+++ b/models/reserve_headroom.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
+try:
+    from models.energy_limits import StorageEnergyState, limit_active_power_by_energy
+except ModuleNotFoundError:
+    from energy_limits import StorageEnergyState, limit_active_power_by_energy
+
+
+@dataclass(frozen=True)
+class ReserveHeadroom:
+    """Sustained active-power reserve available around a feasible baseline."""
+
+    baseline_active_mw: float
+    duration_minutes: float
+    upward_limit_active_mw: float
+    downward_limit_active_mw: float
+    upward_reserve_mw: float
+    downward_reserve_mw: float
+    upward_energy_limited: bool
+    downward_energy_limited: bool
+
+
+def calculate_reserve_headroom(
+    baseline_active_mw: float,
+    duration_minutes: float,
+    maximum_discharge_mw: float,
+    maximum_charge_mw: float,
+    state: StorageEnergyState,
+) -> ReserveHeadroom:
+    """Return sustained upward and downward reserve for one response duration."""
+
+    values = {
+        "baseline_active_mw": baseline_active_mw,
+        "maximum_discharge_mw": maximum_discharge_mw,
+        "maximum_charge_mw": maximum_charge_mw,
+    }
+    for name, value in values.items():
+        if not math.isfinite(value):
+            raise ValueError(f"{name} must be finite")
+    if maximum_discharge_mw < 0.0:
+        raise ValueError("maximum_discharge_mw must be nonnegative")
+    if maximum_charge_mw < 0.0:
+        raise ValueError("maximum_charge_mw must be nonnegative")
+    if not -maximum_charge_mw <= baseline_active_mw <= maximum_discharge_mw:
+        raise ValueError("baseline_active_mw must be within the configured power limits")
+
+    baseline = limit_active_power_by_energy(
+        baseline_active_mw,
+        duration_minutes,
+        state,
+    )
+    if baseline.energy_limited:
+        raise ValueError(
+            "baseline_active_mw cannot be sustained for the response duration"
+        )
+
+    upward = limit_active_power_by_energy(
+        maximum_discharge_mw,
+        duration_minutes,
+        state,
+    )
+    downward = limit_active_power_by_energy(
+        -maximum_charge_mw,
+        duration_minutes,
+        state,
+    )
+
+    return ReserveHeadroom(
+        baseline_active_mw=baseline_active_mw,
+        duration_minutes=duration_minutes,
+        upward_limit_active_mw=upward.delivered_active_mw,
+        downward_limit_active_mw=downward.delivered_active_mw,
+        upward_reserve_mw=max(
+            0.0,
+            upward.delivered_active_mw - baseline_active_mw,
+        ),
+        downward_reserve_mw=max(
+            0.0,
+            baseline_active_mw - downward.delivered_active_mw,
+        ),
+        upward_energy_limited=upward.energy_limited,
+        downward_energy_limited=downward.energy_limited,
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Calculate sustained active-power reserve around a baseline."
+    )
+    parser.add_argument("--baseline-active-mw", type=float, required=True)
+    parser.add_argument("--duration-minutes", type=float, required=True)
+    parser.add_argument("--maximum-discharge-mw", type=float, required=True)
+    parser.add_argument("--maximum-charge-mw", type=float, required=True)
+    parser.add_argument("--energy-capacity-mwh", type=float, required=True)
+    parser.add_argument("--initial-soc", type=float, required=True)
+    parser.add_argument("--minimum-soc", type=float, default=0.10)
+    parser.add_argument("--maximum-soc", type=float, default=0.90)
+    parser.add_argument("--charge-efficiency", type=float, default=0.95)
+    parser.add_argument("--discharge-efficiency", type=float, default=0.95)
+    parser.add_argument("--auxiliary-load-mw", type=float, default=0.0)
+    parser.add_argument("--self-discharge-rate-per-hour", type=float, default=0.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    result = calculate_reserve_headroom(
+        baseline_active_mw=args.baseline_active_mw,
+        duration_minutes=args.duration_minutes,
+        maximum_discharge_mw=args.maximum_discharge_mw,
+        maximum_charge_mw=args.maximum_charge_mw,
+        state=StorageEnergyState(
+            energy_capacity_mwh=args.energy_capacity_mwh,
+            initial_soc=args.initial_soc,
+            minimum_soc=args.minimum_soc,
+            maximum_soc=args.maximum_soc,
+            charge_efficiency=args.charge_efficiency,
+            discharge_efficiency=args.discharge_efficiency,
+            auxiliary_load_mw=args.auxiliary_load_mw,
+            self_discharge_rate_per_hour=args.self_discharge_rate_per_hour,
+        ),
+    )
+
+    print(f"Response duration: {result.duration_minutes:.3f} minutes")
+    print(f"Baseline active power: {result.baseline_active_mw:.3f} MW")
+    print(f"Upward active-power limit: {result.upward_limit_active_mw:.3f} MW")
+    print(
+        "Downward active-power limit: "
+        f"{result.downward_limit_active_mw:.3f} MW"
+    )
+    print(f"Upward reserve: {result.upward_reserve_mw:.3f} MW")
+    print(f"Downward reserve: {result.downward_reserve_mw:.3f} MW")
+    print(f"Upward energy limited: {str(result.upward_energy_limited).lower()}")
+    print(
+        "Downward energy limited: "
+        f"{str(result.downward_energy_limited).lower()}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reserve_headroom.py
+++ b/tests/test_reserve_headroom.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import unittest
+
+from models.energy_limits import StorageEnergyState
+from models.reserve_headroom import calculate_reserve_headroom, main
+
+
+class ReserveHeadroomTests(unittest.TestCase):
+    def test_soc_headroom_limits_both_reserve_directions(self):
+        result = calculate_reserve_headroom(
+            baseline_active_mw=10.0,
+            duration_minutes=30.0,
+            maximum_discharge_mw=100.0,
+            maximum_charge_mw=100.0,
+            state=StorageEnergyState(
+                energy_capacity_mwh=100.0,
+                initial_soc=0.50,
+                minimum_soc=0.20,
+                maximum_soc=0.80,
+                charge_efficiency=1.0,
+                discharge_efficiency=1.0,
+            ),
+        )
+
+        self.assertAlmostEqual(result.upward_limit_active_mw, 60.0)
+        self.assertAlmostEqual(result.downward_limit_active_mw, -60.0)
+        self.assertAlmostEqual(result.upward_reserve_mw, 50.0)
+        self.assertAlmostEqual(result.downward_reserve_mw, 70.0)
+        self.assertTrue(result.upward_energy_limited)
+        self.assertTrue(result.downward_energy_limited)
+
+    def test_efficiency_reduces_sustained_discharge_reserve(self):
+        result = calculate_reserve_headroom(
+            baseline_active_mw=0.0,
+            duration_minutes=15.0,
+            maximum_discharge_mw=100.0,
+            maximum_charge_mw=100.0,
+            state=StorageEnergyState(
+                energy_capacity_mwh=100.0,
+                initial_soc=0.30,
+                minimum_soc=0.20,
+                maximum_soc=0.90,
+                charge_efficiency=0.90,
+                discharge_efficiency=0.80,
+            ),
+        )
+
+        self.assertAlmostEqual(result.upward_reserve_mw, 32.0)
+        self.assertAlmostEqual(result.downward_reserve_mw, 100.0)
+        self.assertTrue(result.upward_energy_limited)
+        self.assertFalse(result.downward_energy_limited)
+
+    def test_power_limits_bind_when_energy_is_available(self):
+        result = calculate_reserve_headroom(
+            baseline_active_mw=-5.0,
+            duration_minutes=5.0,
+            maximum_discharge_mw=20.0,
+            maximum_charge_mw=15.0,
+            state=StorageEnergyState(
+                energy_capacity_mwh=200.0,
+                initial_soc=0.50,
+            ),
+        )
+
+        self.assertEqual(result.upward_limit_active_mw, 20.0)
+        self.assertEqual(result.downward_limit_active_mw, -15.0)
+        self.assertEqual(result.upward_reserve_mw, 25.0)
+        self.assertEqual(result.downward_reserve_mw, 10.0)
+        self.assertFalse(result.upward_energy_limited)
+        self.assertFalse(result.downward_energy_limited)
+
+    def test_rejects_invalid_limits_and_unsustainable_baseline(self):
+        state = StorageEnergyState(
+            energy_capacity_mwh=10.0,
+            initial_soc=0.30,
+            minimum_soc=0.20,
+            discharge_efficiency=1.0,
+        )
+        with self.assertRaisesRegex(ValueError, "maximum_discharge_mw"):
+            calculate_reserve_headroom(0.0, 10.0, -1.0, 1.0, state)
+        with self.assertRaisesRegex(ValueError, "configured power limits"):
+            calculate_reserve_headroom(2.0, 10.0, 1.0, 1.0, state)
+        with self.assertRaisesRegex(ValueError, "cannot be sustained"):
+            calculate_reserve_headroom(2.0, 60.0, 2.0, 2.0, state)
+
+    def test_operating_sweep_preserves_nonnegative_reserves(self):
+        for initial_soc in (0.15, 0.30, 0.50, 0.70, 0.85):
+            with self.subTest(initial_soc=initial_soc):
+                result = calculate_reserve_headroom(
+                    baseline_active_mw=0.0,
+                    duration_minutes=20.0,
+                    maximum_discharge_mw=50.0,
+                    maximum_charge_mw=40.0,
+                    state=StorageEnergyState(100.0, initial_soc),
+                )
+                self.assertGreaterEqual(result.upward_reserve_mw, 0.0)
+                self.assertGreaterEqual(result.downward_reserve_mw, 0.0)
+                self.assertLessEqual(result.upward_limit_active_mw, 50.0)
+                self.assertGreaterEqual(result.downward_limit_active_mw, -40.0)
+
+    def test_cli_reports_directional_reserve_and_binding_limit(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--baseline-active-mw",
+                    "10",
+                    "--duration-minutes",
+                    "30",
+                    "--maximum-discharge-mw",
+                    "100",
+                    "--maximum-charge-mw",
+                    "100",
+                    "--energy-capacity-mwh",
+                    "100",
+                    "--initial-soc",
+                    "0.5",
+                    "--minimum-soc",
+                    "0.2",
+                    "--maximum-soc",
+                    "0.8",
+                    "--charge-efficiency",
+                    "1",
+                    "--discharge-efficiency",
+                    "1",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Upward reserve: 50.000 MW", output)
+        self.assertIn("Downward reserve: 70.000 MW", output)
+        self.assertIn("Upward energy limited: true", output)
+        self.assertIn("Downward energy limited: true", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dependency-free sustained reserve-headroom model around a feasible active-power baseline
- report directional power limits, reserve MW, and whether SOC energy is binding
- add boundary, efficiency, validation, sweep, and CLI coverage
- document the assumptions and execute the reference case in CI

## Why
Storage reserve claims need to distinguish instantaneous nameplate capability from power that can be sustained for the required response duration. This composes the existing SOC and standing-loss model into a reviewable directional reserve calculation.

## Validation
- `git diff --check`
- `python -m unittest discover -s tests -v` (136 tests)
- `python -m compileall -q models tests`
- reference CLI case for a 30-minute reserve assessment