### PR TITLE
Add reserve sequence audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ python models/reserve_headroom.py `
   --energy-capacity-mwh 100 --initial-soc 0.50 `
   --minimum-soc 0.20 --maximum-soc 0.80 `
   --charge-efficiency 1 --discharge-efficiency 1
+python models/reserve_sequence.py `
+  --baseline-active-mw-profile 20,20,20 `
+  --interval-duration-minutes-profile 30,30,30 `
+  --response-duration-minutes 30 `
+  --maximum-discharge-mw 100 --maximum-charge-mw 100 `
+  --energy-capacity-mwh 100 --initial-soc 0.80 `
+  --minimum-soc 0.20 --maximum-soc 0.90 `
+  --charge-efficiency 1 --discharge-efficiency 1
 python models/grid_support_sequence.py `
   --frequency-hz-profile 50,49.5,50.5 `
   --voltage-pu-profile 1,0.92,1.08 `

--- a/models/README.md
+++ b/models/README.md
@@ -562,6 +562,43 @@ model activation delay, ramping, P-Q competition, thermal derating, reserve
 recovery, simultaneous services, or probabilistic availability. Compose those
 constraints separately before making a market or grid-code claim.
 
+## Reserve Sequence Audit
+
+[`reserve_sequence.py`](reserve_sequence.py) applies the sustained reserve
+calculation before every interval in a baseline schedule, then advances SOC
+through the interval with the same exact standing-loss and conversion model.
+This makes reserve erosion or recovery from earlier dispatch visible instead
+of treating every commitment as if it started from the original SOC.
+
+Run three 30-minute discharge intervals with a 30-minute reserve requirement:
+
+```powershell
+python models/reserve_sequence.py `
+  --baseline-active-mw-profile 20,20,20 `
+  --interval-duration-minutes-profile 30,30,30 `
+  --response-duration-minutes 30 `
+  --maximum-discharge-mw 100 --maximum-charge-mw 100 `
+  --energy-capacity-mwh 100 --initial-soc 0.80 `
+  --minimum-soc 0.20 --maximum-soc 0.90 `
+  --charge-efficiency 1 --discharge-efficiency 1
+```
+
+Expected schedule minima:
+
+```text
+Ending SOC: 0.5000
+Minimum upward reserve: 60.000 MW (interval 3)
+Minimum downward reserve: 40.000 MW (interval 1)
+Reserve energy-limited intervals: upward=1, downward=3
+```
+
+The baseline schedule is a firm input: an interval is rejected if its baseline
+cannot be delivered for the full schedule duration. Reserve limits are assessed
+from interval-start SOC and represent replacement setpoints held for the stated
+response duration; they do not simulate activation energy in addition to the
+baseline trajectory. Ramping, P-Q competition, temperature derating, recovery
+requirements, and overlapping reserve activations remain separate constraints.
+
 ## Multi-Service Grid-Support Sequence
 
 [`grid_support_sequence.py`](grid_support_sequence.py) composes the existing

--- a/models/reserve_sequence.py
+++ b/models/reserve_sequence.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass, replace
+from typing import Sequence
+
+try:
+    from models.energy_limits import (
+        EnergyLimitedDispatch,
+        StorageEnergyState,
+        limit_active_power_by_energy,
+    )
+    from models.reserve_headroom import ReserveHeadroom, calculate_reserve_headroom
+except ModuleNotFoundError:
+    from energy_limits import (
+        EnergyLimitedDispatch,
+        StorageEnergyState,
+        limit_active_power_by_energy,
+    )
+    from reserve_headroom import ReserveHeadroom, calculate_reserve_headroom
+
+
+@dataclass(frozen=True)
+class ReserveSequenceInterval:
+    """Reserve assessment and baseline dispatch for one schedule interval."""
+
+    index: int
+    reserve: ReserveHeadroom
+    baseline_dispatch: EnergyLimitedDispatch
+
+
+@dataclass(frozen=True)
+class ReserveSequenceAudit:
+    """SOC-aware reserve margins carried through a baseline schedule."""
+
+    intervals: tuple[ReserveSequenceInterval, ...]
+    response_duration_minutes: float
+    initial_soc: float
+    ending_soc: float
+    total_schedule_duration_minutes: float
+    baseline_ac_energy_mwh: float
+    stored_energy_change_mwh: float
+    auxiliary_energy_mwh: float
+    self_discharge_energy_mwh: float
+    soc_balance_error: float
+    minimum_upward_reserve_mw: float
+    minimum_upward_reserve_interval: int
+    minimum_downward_reserve_mw: float
+    minimum_downward_reserve_interval: int
+    upward_energy_limited_interval_count: int
+    downward_energy_limited_interval_count: int
+
+
+def audit_reserve_sequence(
+    baseline_active_mw: Sequence[float],
+    interval_duration_minutes: Sequence[float],
+    response_duration_minutes: float,
+    maximum_discharge_mw: float,
+    maximum_charge_mw: float,
+    state: StorageEnergyState,
+) -> ReserveSequenceAudit:
+    """Assess sustained reserve before each baseline interval and carry SOC."""
+
+    baselines = tuple(baseline_active_mw)
+    durations = tuple(interval_duration_minutes)
+    if not baselines:
+        raise ValueError("baseline_active_mw must contain at least one interval")
+    if len(baselines) != len(durations):
+        raise ValueError(
+            "baseline_active_mw and interval_duration_minutes must have equal lengths"
+        )
+
+    state.validate()
+    interval_results: list[ReserveSequenceInterval] = []
+    current_state = state
+    for index, (baseline_mw, interval_minutes) in enumerate(
+        zip(baselines, durations, strict=True),
+        start=1,
+    ):
+        reserve = calculate_reserve_headroom(
+            baseline_active_mw=baseline_mw,
+            duration_minutes=response_duration_minutes,
+            maximum_discharge_mw=maximum_discharge_mw,
+            maximum_charge_mw=maximum_charge_mw,
+            state=current_state,
+        )
+        baseline_dispatch = limit_active_power_by_energy(
+            baseline_mw,
+            interval_minutes,
+            current_state,
+        )
+        if baseline_dispatch.energy_limited:
+            raise ValueError(
+                f"baseline_active_mw interval {index} cannot be sustained for "
+                "its schedule duration"
+            )
+        interval_results.append(
+            ReserveSequenceInterval(
+                index=index,
+                reserve=reserve,
+                baseline_dispatch=baseline_dispatch,
+            )
+        )
+        current_state = replace(
+            current_state,
+            initial_soc=baseline_dispatch.ending_soc,
+        )
+
+    intervals = tuple(interval_results)
+    minimum_upward = min(
+        intervals,
+        key=lambda interval: interval.reserve.upward_reserve_mw,
+    )
+    minimum_downward = min(
+        intervals,
+        key=lambda interval: interval.reserve.downward_reserve_mw,
+    )
+    stored_energy_change_mwh = math.fsum(
+        interval.baseline_dispatch.stored_energy_change_mwh
+        for interval in intervals
+    )
+    ending_soc = intervals[-1].baseline_dispatch.ending_soc
+    expected_ending_soc = (
+        state.initial_soc + stored_energy_change_mwh / state.energy_capacity_mwh
+    )
+
+    return ReserveSequenceAudit(
+        intervals=intervals,
+        response_duration_minutes=response_duration_minutes,
+        initial_soc=state.initial_soc,
+        ending_soc=ending_soc,
+        total_schedule_duration_minutes=math.fsum(durations),
+        baseline_ac_energy_mwh=math.fsum(
+            baseline_mw * duration_minutes / 60.0
+            for baseline_mw, duration_minutes in zip(
+                baselines,
+                durations,
+                strict=True,
+            )
+        ),
+        stored_energy_change_mwh=stored_energy_change_mwh,
+        auxiliary_energy_mwh=math.fsum(
+            interval.baseline_dispatch.auxiliary_energy_mwh
+            for interval in intervals
+        ),
+        self_discharge_energy_mwh=math.fsum(
+            interval.baseline_dispatch.self_discharge_energy_mwh
+            for interval in intervals
+        ),
+        soc_balance_error=ending_soc - expected_ending_soc,
+        minimum_upward_reserve_mw=minimum_upward.reserve.upward_reserve_mw,
+        minimum_upward_reserve_interval=minimum_upward.index,
+        minimum_downward_reserve_mw=minimum_downward.reserve.downward_reserve_mw,
+        minimum_downward_reserve_interval=minimum_downward.index,
+        upward_energy_limited_interval_count=sum(
+            interval.reserve.upward_energy_limited for interval in intervals
+        ),
+        downward_energy_limited_interval_count=sum(
+            interval.reserve.downward_energy_limited for interval in intervals
+        ),
+    )
+
+
+def _parse_number_series(value: str) -> tuple[float, ...]:
+    raw_values = value.split(",")
+    if not raw_values or any(not raw_value.strip() for raw_value in raw_values):
+        raise argparse.ArgumentTypeError(
+            "profiles must be comma-separated numbers without empty entries"
+        )
+    try:
+        values = tuple(float(raw_value) for raw_value in raw_values)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            "profiles must contain only comma-separated numbers"
+        ) from error
+    if any(not math.isfinite(number) for number in values):
+        raise argparse.ArgumentTypeError("profile values must be finite")
+    return values
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Audit sustained reserve through a baseline schedule."
+    )
+    parser.add_argument(
+        "--baseline-active-mw-profile",
+        type=_parse_number_series,
+        required=True,
+    )
+    parser.add_argument(
+        "--interval-duration-minutes-profile",
+        type=_parse_number_series,
+        required=True,
+    )
+    parser.add_argument("--response-duration-minutes", type=float, required=True)
+    parser.add_argument("--maximum-discharge-mw", type=float, required=True)
+    parser.add_argument("--maximum-charge-mw", type=float, required=True)
+    parser.add_argument("--energy-capacity-mwh", type=float, required=True)
+    parser.add_argument("--initial-soc", type=float, required=True)
+    parser.add_argument("--minimum-soc", type=float, default=0.10)
+    parser.add_argument("--maximum-soc", type=float, default=0.90)
+    parser.add_argument("--charge-efficiency", type=float, default=0.95)
+    parser.add_argument("--discharge-efficiency", type=float, default=0.95)
+    parser.add_argument("--auxiliary-load-mw", type=float, default=0.0)
+    parser.add_argument("--self-discharge-rate-per-hour", type=float, default=0.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    result = audit_reserve_sequence(
+        baseline_active_mw=args.baseline_active_mw_profile,
+        interval_duration_minutes=args.interval_duration_minutes_profile,
+        response_duration_minutes=args.response_duration_minutes,
+        maximum_discharge_mw=args.maximum_discharge_mw,
+        maximum_charge_mw=args.maximum_charge_mw,
+        state=StorageEnergyState(
+            energy_capacity_mwh=args.energy_capacity_mwh,
+            initial_soc=args.initial_soc,
+            minimum_soc=args.minimum_soc,
+            maximum_soc=args.maximum_soc,
+            charge_efficiency=args.charge_efficiency,
+            discharge_efficiency=args.discharge_efficiency,
+            auxiliary_load_mw=args.auxiliary_load_mw,
+            self_discharge_rate_per_hour=args.self_discharge_rate_per_hour,
+        ),
+    )
+
+    print(f"Intervals: {len(result.intervals)}")
+    print(f"Response duration: {result.response_duration_minutes:.3f} minutes")
+    print(f"Initial SOC: {result.initial_soc:.4f}")
+    print(f"Ending SOC: {result.ending_soc:.4f}")
+    print(f"Baseline AC energy: {result.baseline_ac_energy_mwh:.3f} MWh")
+    print(
+        "Minimum upward reserve: "
+        f"{result.minimum_upward_reserve_mw:.3f} MW "
+        f"(interval {result.minimum_upward_reserve_interval})"
+    )
+    print(
+        "Minimum downward reserve: "
+        f"{result.minimum_downward_reserve_mw:.3f} MW "
+        f"(interval {result.minimum_downward_reserve_interval})"
+    )
+    print(
+        "Reserve energy-limited intervals: "
+        f"upward={result.upward_energy_limited_interval_count}, "
+        f"downward={result.downward_energy_limited_interval_count}"
+    )
+    print(f"Auxiliary energy: {result.auxiliary_energy_mwh:.3f} MWh")
+    print(f"Self-discharge energy: {result.self_discharge_energy_mwh:.3f} MWh")
+    print(f"SOC balance error: {result.soc_balance_error:.3e}")
+    for interval in result.intervals:
+        print(
+            f"Interval {interval.index}: "
+            f"baseline={interval.reserve.baseline_active_mw:.3f} MW, "
+            f"initial_soc={interval.baseline_dispatch.initial_soc:.4f}, "
+            f"ending_soc={interval.baseline_dispatch.ending_soc:.4f}, "
+            f"upward={interval.reserve.upward_reserve_mw:.3f} MW, "
+            f"downward={interval.reserve.downward_reserve_mw:.3f} MW"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reserve_sequence.py
+++ b/tests/test_reserve_sequence.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import unittest
+
+from models.energy_limits import StorageEnergyState, limit_active_power_by_energy
+from models.reserve_headroom import calculate_reserve_headroom
+from models.reserve_sequence import audit_reserve_sequence, main
+
+
+class ReserveSequenceTests(unittest.TestCase):
+    def test_discharge_schedule_carries_soc_and_reduces_upward_margin(self):
+        result = audit_reserve_sequence(
+            baseline_active_mw=[20.0, 20.0, 20.0],
+            interval_duration_minutes=[30.0, 30.0, 30.0],
+            response_duration_minutes=30.0,
+            maximum_discharge_mw=100.0,
+            maximum_charge_mw=100.0,
+            state=StorageEnergyState(
+                100.0,
+                0.80,
+                minimum_soc=0.20,
+                maximum_soc=0.90,
+                charge_efficiency=1.0,
+                discharge_efficiency=1.0,
+            ),
+        )
+
+        self.assertEqual(
+            [interval.reserve.upward_reserve_mw for interval in result.intervals],
+            [80.0, 80.0, 60.0],
+        )
+        self.assertEqual(
+            [interval.reserve.downward_reserve_mw for interval in result.intervals],
+            [40.0, 60.0, 80.0],
+        )
+        self.assertAlmostEqual(result.ending_soc, 0.50)
+        self.assertEqual(result.minimum_upward_reserve_interval, 3)
+        self.assertEqual(result.minimum_downward_reserve_interval, 1)
+        self.assertEqual(result.upward_energy_limited_interval_count, 1)
+        self.assertEqual(result.downward_energy_limited_interval_count, 3)
+
+    def test_single_interval_matches_standalone_models(self):
+        state = StorageEnergyState(
+            100.0,
+            0.50,
+            minimum_soc=0.20,
+            maximum_soc=0.80,
+            charge_efficiency=0.90,
+            discharge_efficiency=0.80,
+        )
+        result = audit_reserve_sequence(
+            [10.0],
+            [15.0],
+            30.0,
+            100.0,
+            100.0,
+            state,
+        )
+        expected_reserve = calculate_reserve_headroom(
+            10.0,
+            30.0,
+            100.0,
+            100.0,
+            state,
+        )
+        expected_dispatch = limit_active_power_by_energy(10.0, 15.0, state)
+
+        self.assertEqual(result.intervals[0].reserve, expected_reserve)
+        self.assertEqual(result.intervals[0].baseline_dispatch, expected_dispatch)
+
+    def test_charge_schedule_recovers_upward_reserve(self):
+        result = audit_reserve_sequence(
+            [-20.0, -20.0, -20.0],
+            [30.0, 30.0, 30.0],
+            30.0,
+            100.0,
+            100.0,
+            StorageEnergyState(
+                100.0,
+                0.30,
+                minimum_soc=0.20,
+                maximum_soc=0.90,
+                charge_efficiency=1.0,
+                discharge_efficiency=1.0,
+            ),
+        )
+
+        self.assertEqual(
+            [interval.reserve.upward_reserve_mw for interval in result.intervals],
+            [40.0, 60.0, 80.0],
+        )
+        self.assertAlmostEqual(result.ending_soc, 0.60)
+
+    def test_standing_losses_are_carried_and_balance_closes(self):
+        result = audit_reserve_sequence(
+            [0.0, 0.0],
+            [60.0, 60.0],
+            15.0,
+            100.0,
+            100.0,
+            StorageEnergyState(
+                100.0,
+                0.80,
+                auxiliary_load_mw=1.0,
+                self_discharge_rate_per_hour=0.01,
+            ),
+        )
+
+        self.assertLess(result.ending_soc, 0.78)
+        self.assertAlmostEqual(result.auxiliary_energy_mwh, 2.0)
+        self.assertGreater(result.self_discharge_energy_mwh, 0.0)
+        self.assertAlmostEqual(result.soc_balance_error, 0.0)
+        self.assertEqual(
+            result.intervals[1].baseline_dispatch.initial_soc,
+            result.intervals[0].baseline_dispatch.ending_soc,
+        )
+
+    def test_unsustainable_schedule_interval_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "interval 1 cannot be sustained"):
+            audit_reserve_sequence(
+                [50.0],
+                [60.0],
+                5.0,
+                100.0,
+                100.0,
+                StorageEnergyState(
+                    100.0,
+                    0.50,
+                    minimum_soc=0.20,
+                    discharge_efficiency=1.0,
+                ),
+            )
+
+    def test_profile_inputs_are_validated(self):
+        state = StorageEnergyState(100.0, 0.50)
+        with self.assertRaisesRegex(ValueError, "at least one"):
+            audit_reserve_sequence([], [], 15.0, 100.0, 100.0, state)
+        with self.assertRaisesRegex(ValueError, "equal lengths"):
+            audit_reserve_sequence([0.0], [15.0, 15.0], 15.0, 100.0, 100.0, state)
+        with self.assertRaisesRegex(ValueError, "duration_minutes"):
+            audit_reserve_sequence([0.0], [15.0], 0.0, 100.0, 100.0, state)
+
+    def test_cli_reports_schedule_minima_and_interval_evidence(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--baseline-active-mw-profile",
+                    "20,20,20",
+                    "--interval-duration-minutes-profile",
+                    "30,30,30",
+                    "--response-duration-minutes",
+                    "30",
+                    "--maximum-discharge-mw",
+                    "100",
+                    "--maximum-charge-mw",
+                    "100",
+                    "--energy-capacity-mwh",
+                    "100",
+                    "--initial-soc",
+                    "0.8",
+                    "--minimum-soc",
+                    "0.2",
+                    "--maximum-soc",
+                    "0.9",
+                    "--charge-efficiency",
+                    "1",
+                    "--discharge-efficiency",
+                    "1",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Ending SOC: 0.5000", output)
+        self.assertIn("Minimum upward reserve: 60.000 MW (interval 3)", output)
+        self.assertIn("Minimum downward reserve: 40.000 MW (interval 1)", output)
+        self.assertIn("upward=1, downward=3", output)
+        self.assertIn("Interval 3: baseline=20.000 MW", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- assess sustained upward and downward reserve before every interval in a baseline schedule
- carry SOC, auxiliary demand, self-discharge, and conversion effects between commitments
- reject baseline intervals that cannot be delivered for their full schedule duration
- report schedule minima, binding intervals, and per-interval reserve evidence

## Why
A single operating-point reserve calculation can overstate later commitments after earlier dispatch consumes energy. This audit reuses the exact existing energy limiter so reserve margins follow the actual scheduled SOC trajectory.

## Validation
- Python: 143 unit tests passed
- documented three-interval CLI scenario passed
- bytecode compilation passed
- git diff validation passed