### PR TITLE
Compose reserve with P-Q capability

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -59,6 +59,17 @@ jobs:
           --energy-capacity-mwh 100 --initial-soc 0.5
           --minimum-soc 0.2 --maximum-soc 0.8
           --charge-efficiency 1 --discharge-efficiency 1
+          --reactive-mvar 80 --limit-mva 100
+
+      - name: Run P-Q constrained reserve sequence
+        run: >-
+          python models/reserve_sequence.py
+          --baseline-active-mw-profile 10,10
+          --interval-duration-minutes-profile 15,15
+          --response-duration-minutes 30
+          --maximum-discharge-mw 100 --maximum-charge-mw 100
+          --energy-capacity-mwh 1000 --initial-soc 0.5
+          --reactive-mvar 80 --limit-mva 100
 
       - name: Run sampled capability envelope
         run: >-

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ python models/reserve_headroom.py `
   --maximum-discharge-mw 100 --maximum-charge-mw 100 `
   --energy-capacity-mwh 100 --initial-soc 0.50 `
   --minimum-soc 0.20 --maximum-soc 0.80 `
-  --charge-efficiency 1 --discharge-efficiency 1
+  --charge-efficiency 1 --discharge-efficiency 1 `
+  --reactive-mvar 80 --limit-mva 100
 python models/reserve_sequence.py `
   --baseline-active-mw-profile 20,20,20 `
   --interval-duration-minutes-profile 30,30,30 `
@@ -153,7 +154,8 @@ python models/reserve_sequence.py `
   --maximum-discharge-mw 100 --maximum-charge-mw 100 `
   --energy-capacity-mwh 100 --initial-soc 0.80 `
   --minimum-soc 0.20 --maximum-soc 0.90 `
-  --charge-efficiency 1 --discharge-efficiency 1
+  --charge-efficiency 1 --discharge-efficiency 1 `
+  --reactive-mvar 80 --limit-mva 100
 python models/grid_support_sequence.py `
   --frequency-hz-profile 50,49.5,50.5 `
   --voltage-pu-profile 1,0.92,1.08 `

--- a/models/README.md
+++ b/models/README.md
@@ -527,7 +527,9 @@ estimate, warranty interpretation, or remaining-life prediction.
 discharge limits into sustained upward and downward active-power reserve around
 a feasible baseline. It evaluates the configured response duration through the
 same SOC and standing-loss limiter, so a result distinguishes a power-limited
-reserve from one constrained by stored-energy headroom.
+reserve from one constrained by stored-energy headroom. An optional circular,
+symmetric sampled, or directional P-Q boundary also preserves a fixed reactive
+power obligation and distinguishes capability-limited reserve.
 
 Run a 30-minute assessment around a 10 MW discharge baseline:
 
@@ -556,11 +558,38 @@ the sustained discharge limit minus the baseline. Downward reserve is the
 baseline minus the sustained charge limit, so a discharging baseline can have
 more downward headroom than the charge limit magnitude alone.
 
+For example, holding 80 MVAr on a 100 MVA circular boundary leaves 60 MW in
+either active-power direction. With ample stored energy, the same 10 MW
+baseline therefore has 50 MW upward and 70 MW downward reserve:
+
+```powershell
+python models/reserve_headroom.py `
+  --baseline-active-mw 10 --duration-minutes 30 `
+  --maximum-discharge-mw 100 --maximum-charge-mw 100 `
+  --energy-capacity-mwh 1000 --initial-soc 0.50 `
+  --reactive-mvar 80 --limit-mva 100
+```
+
+```text
+Reactive power obligation: 80.000 MVAr
+Upward active-power limit: 60.000 MW
+Downward active-power limit: -60.000 MW
+Upward capability limited: true
+Downward capability limited: true
+```
+
+Use `--curve-csv` for the symmetric sampled boundary or
+`--directional-curve-csv` for the four-quadrant envelope. Reactive power is held
+with reactive priority; the audit rejects a reactive obligation or baseline
+that the selected boundary cannot deliver. Capability is applied before the
+energy limiter, so curtailment by each stage remains independently visible.
+
 The baseline must itself remain feasible for the full response duration. This
 reference evaluates replacement setpoints from the initial state; it does not
-model activation delay, ramping, P-Q competition, thermal derating, reserve
-recovery, simultaneous services, or probabilistic availability. Compose those
-constraints separately before making a market or grid-code claim.
+model activation delay, ramping, time-varying reactive dispatch, thermal
+derating, reserve recovery, simultaneous services, or probabilistic
+availability. Compose those constraints separately before making a market or
+grid-code claim.
 
 ## Reserve Sequence Audit
 
@@ -596,8 +625,12 @@ The baseline schedule is a firm input: an interval is rejected if its baseline
 cannot be delivered for the full schedule duration. Reserve limits are assessed
 from interval-start SOC and represent replacement setpoints held for the stated
 response duration; they do not simulate activation energy in addition to the
-baseline trajectory. Ramping, P-Q competition, temperature derating, recovery
-requirements, and overlapping reserve activations remain separate constraints.
+baseline trajectory. Ramping, time-varying reactive dispatch, temperature
+derating, recovery requirements, and overlapping reserve activations remain
+separate constraints. The same `--reactive-mvar` and mutually exclusive P-Q
+boundary arguments carry a fixed reactive obligation through every interval;
+the summary reports how many upward and downward intervals are capability
+limited independently of their energy-limit counts.
 
 ## Multi-Service Grid-Support Sequence
 

--- a/models/reserve_headroom.py
+++ b/models/reserve_headroom.py
@@ -3,12 +3,27 @@ from __future__ import annotations
 import argparse
 import math
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Sequence
 
 try:
     from models.energy_limits import StorageEnergyState, limit_active_power_by_energy
+    from models.pq_capability import (
+        CapabilityBoundary,
+        PowerPriority,
+        allocate_power_on_boundary,
+        load_capability_curve_csv,
+        load_directional_capability_csv,
+    )
 except ModuleNotFoundError:
     from energy_limits import StorageEnergyState, limit_active_power_by_energy
+    from pq_capability import (
+        CapabilityBoundary,
+        PowerPriority,
+        allocate_power_on_boundary,
+        load_capability_curve_csv,
+        load_directional_capability_csv,
+    )
 
 
 @dataclass(frozen=True)
@@ -16,6 +31,7 @@ class ReserveHeadroom:
     """Sustained active-power reserve available around a feasible baseline."""
 
     baseline_active_mw: float
+    reactive_power_mvar: float
     duration_minutes: float
     upward_limit_active_mw: float
     downward_limit_active_mw: float
@@ -23,6 +39,29 @@ class ReserveHeadroom:
     downward_reserve_mw: float
     upward_energy_limited: bool
     downward_energy_limited: bool
+    upward_capability_limited: bool
+    downward_capability_limited: bool
+
+
+def _capability_active_limit(
+    requested_active_mw: float,
+    reactive_power_mvar: float,
+    capability_boundary: CapabilityBoundary,
+) -> float:
+    allocation = allocate_power_on_boundary(
+        requested_active_mw,
+        reactive_power_mvar,
+        capability_boundary,
+        PowerPriority.REACTIVE,
+    )
+    if not math.isclose(
+        allocation.reactive_mvar,
+        reactive_power_mvar,
+        rel_tol=0.0,
+        abs_tol=1e-12,
+    ):
+        raise ValueError("reactive_power_mvar exceeds the capability boundary")
+    return allocation.active_mw
 
 
 def calculate_reserve_headroom(
@@ -31,6 +70,9 @@ def calculate_reserve_headroom(
     maximum_discharge_mw: float,
     maximum_charge_mw: float,
     state: StorageEnergyState,
+    *,
+    reactive_power_mvar: float = 0.0,
+    capability_boundary: CapabilityBoundary | None = None,
 ) -> ReserveHeadroom:
     """Return sustained upward and downward reserve for one response duration."""
 
@@ -38,6 +80,7 @@ def calculate_reserve_headroom(
         "baseline_active_mw": baseline_active_mw,
         "maximum_discharge_mw": maximum_discharge_mw,
         "maximum_charge_mw": maximum_charge_mw,
+        "reactive_power_mvar": reactive_power_mvar,
     }
     for name, value in values.items():
         if not math.isfinite(value):
@@ -48,6 +91,54 @@ def calculate_reserve_headroom(
         raise ValueError("maximum_charge_mw must be nonnegative")
     if not -maximum_charge_mw <= baseline_active_mw <= maximum_discharge_mw:
         raise ValueError("baseline_active_mw must be within the configured power limits")
+
+    upward_capability_limit_mw = maximum_discharge_mw
+    downward_capability_limit_mw = -maximum_charge_mw
+    upward_capability_limited = False
+    downward_capability_limited = False
+    if capability_boundary is None:
+        if reactive_power_mvar != 0.0:
+            raise ValueError(
+                "capability_boundary is required when reactive_power_mvar is nonzero"
+            )
+    else:
+        capability_baseline_mw = _capability_active_limit(
+            baseline_active_mw,
+            reactive_power_mvar,
+            capability_boundary,
+        )
+        if not math.isclose(
+            capability_baseline_mw,
+            baseline_active_mw,
+            rel_tol=0.0,
+            abs_tol=1e-12,
+        ):
+            raise ValueError(
+                "baseline_active_mw is outside the capability boundary at the "
+                "configured reactive power"
+            )
+        upward_capability_limit_mw = _capability_active_limit(
+            maximum_discharge_mw,
+            reactive_power_mvar,
+            capability_boundary,
+        )
+        downward_capability_limit_mw = _capability_active_limit(
+            -maximum_charge_mw,
+            reactive_power_mvar,
+            capability_boundary,
+        )
+        upward_capability_limited = not math.isclose(
+            upward_capability_limit_mw,
+            maximum_discharge_mw,
+            rel_tol=0.0,
+            abs_tol=1e-12,
+        )
+        downward_capability_limited = not math.isclose(
+            downward_capability_limit_mw,
+            -maximum_charge_mw,
+            rel_tol=0.0,
+            abs_tol=1e-12,
+        )
 
     baseline = limit_active_power_by_energy(
         baseline_active_mw,
@@ -60,18 +151,19 @@ def calculate_reserve_headroom(
         )
 
     upward = limit_active_power_by_energy(
-        maximum_discharge_mw,
+        upward_capability_limit_mw,
         duration_minutes,
         state,
     )
     downward = limit_active_power_by_energy(
-        -maximum_charge_mw,
+        downward_capability_limit_mw,
         duration_minutes,
         state,
     )
 
     return ReserveHeadroom(
         baseline_active_mw=baseline_active_mw,
+        reactive_power_mvar=reactive_power_mvar,
         duration_minutes=duration_minutes,
         upward_limit_active_mw=upward.delivered_active_mw,
         downward_limit_active_mw=downward.delivered_active_mw,
@@ -85,7 +177,27 @@ def calculate_reserve_headroom(
         ),
         upward_energy_limited=upward.energy_limited,
         downward_energy_limited=downward.energy_limited,
+        upward_capability_limited=upward_capability_limited,
+        downward_capability_limited=downward_capability_limited,
     )
+
+
+def add_capability_boundary_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--reactive-mvar", type=float, default=0.0)
+    boundary = parser.add_mutually_exclusive_group()
+    boundary.add_argument("--limit-mva", type=float)
+    boundary.add_argument("--curve-csv", type=Path)
+    boundary.add_argument("--directional-curve-csv", type=Path)
+
+
+def capability_boundary_from_args(
+    args: argparse.Namespace,
+) -> CapabilityBoundary | None:
+    if args.curve_csv is not None:
+        return load_capability_curve_csv(args.curve_csv)
+    if args.directional_curve_csv is not None:
+        return load_directional_capability_csv(args.directional_curve_csv)
+    return args.limit_mva
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -104,6 +216,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--discharge-efficiency", type=float, default=0.95)
     parser.add_argument("--auxiliary-load-mw", type=float, default=0.0)
     parser.add_argument("--self-discharge-rate-per-hour", type=float, default=0.0)
+    add_capability_boundary_arguments(parser)
     return parser.parse_args(argv)
 
 
@@ -124,10 +237,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             auxiliary_load_mw=args.auxiliary_load_mw,
             self_discharge_rate_per_hour=args.self_discharge_rate_per_hour,
         ),
+        reactive_power_mvar=args.reactive_mvar,
+        capability_boundary=capability_boundary_from_args(args),
     )
 
     print(f"Response duration: {result.duration_minutes:.3f} minutes")
     print(f"Baseline active power: {result.baseline_active_mw:.3f} MW")
+    print(f"Reactive power obligation: {result.reactive_power_mvar:.3f} MVAr")
     print(f"Upward active-power limit: {result.upward_limit_active_mw:.3f} MW")
     print(
         "Downward active-power limit: "
@@ -139,6 +255,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(
         "Downward energy limited: "
         f"{str(result.downward_energy_limited).lower()}"
+    )
+    print(
+        "Upward capability limited: "
+        f"{str(result.upward_capability_limited).lower()}"
+    )
+    print(
+        "Downward capability limited: "
+        f"{str(result.downward_capability_limited).lower()}"
     )
     return 0
 

--- a/models/reserve_sequence.py
+++ b/models/reserve_sequence.py
@@ -11,14 +11,26 @@ try:
         StorageEnergyState,
         limit_active_power_by_energy,
     )
-    from models.reserve_headroom import ReserveHeadroom, calculate_reserve_headroom
+    from models.pq_capability import CapabilityBoundary
+    from models.reserve_headroom import (
+        ReserveHeadroom,
+        add_capability_boundary_arguments,
+        calculate_reserve_headroom,
+        capability_boundary_from_args,
+    )
 except ModuleNotFoundError:
     from energy_limits import (
         EnergyLimitedDispatch,
         StorageEnergyState,
         limit_active_power_by_energy,
     )
-    from reserve_headroom import ReserveHeadroom, calculate_reserve_headroom
+    from pq_capability import CapabilityBoundary
+    from reserve_headroom import (
+        ReserveHeadroom,
+        add_capability_boundary_arguments,
+        calculate_reserve_headroom,
+        capability_boundary_from_args,
+    )
 
 
 @dataclass(frozen=True)
@@ -36,6 +48,7 @@ class ReserveSequenceAudit:
 
     intervals: tuple[ReserveSequenceInterval, ...]
     response_duration_minutes: float
+    reactive_power_mvar: float
     initial_soc: float
     ending_soc: float
     total_schedule_duration_minutes: float
@@ -50,6 +63,8 @@ class ReserveSequenceAudit:
     minimum_downward_reserve_interval: int
     upward_energy_limited_interval_count: int
     downward_energy_limited_interval_count: int
+    upward_capability_limited_interval_count: int
+    downward_capability_limited_interval_count: int
 
 
 def audit_reserve_sequence(
@@ -59,6 +74,9 @@ def audit_reserve_sequence(
     maximum_discharge_mw: float,
     maximum_charge_mw: float,
     state: StorageEnergyState,
+    *,
+    reactive_power_mvar: float = 0.0,
+    capability_boundary: CapabilityBoundary | None = None,
 ) -> ReserveSequenceAudit:
     """Assess sustained reserve before each baseline interval and carry SOC."""
 
@@ -84,6 +102,8 @@ def audit_reserve_sequence(
             maximum_discharge_mw=maximum_discharge_mw,
             maximum_charge_mw=maximum_charge_mw,
             state=current_state,
+            reactive_power_mvar=reactive_power_mvar,
+            capability_boundary=capability_boundary,
         )
         baseline_dispatch = limit_active_power_by_energy(
             baseline_mw,
@@ -128,6 +148,7 @@ def audit_reserve_sequence(
     return ReserveSequenceAudit(
         intervals=intervals,
         response_duration_minutes=response_duration_minutes,
+        reactive_power_mvar=reactive_power_mvar,
         initial_soc=state.initial_soc,
         ending_soc=ending_soc,
         total_schedule_duration_minutes=math.fsum(durations),
@@ -158,6 +179,12 @@ def audit_reserve_sequence(
         ),
         downward_energy_limited_interval_count=sum(
             interval.reserve.downward_energy_limited for interval in intervals
+        ),
+        upward_capability_limited_interval_count=sum(
+            interval.reserve.upward_capability_limited for interval in intervals
+        ),
+        downward_capability_limited_interval_count=sum(
+            interval.reserve.downward_capability_limited for interval in intervals
         ),
     )
 
@@ -204,6 +231,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--discharge-efficiency", type=float, default=0.95)
     parser.add_argument("--auxiliary-load-mw", type=float, default=0.0)
     parser.add_argument("--self-discharge-rate-per-hour", type=float, default=0.0)
+    add_capability_boundary_arguments(parser)
     return parser.parse_args(argv)
 
 
@@ -225,10 +253,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             auxiliary_load_mw=args.auxiliary_load_mw,
             self_discharge_rate_per_hour=args.self_discharge_rate_per_hour,
         ),
+        reactive_power_mvar=args.reactive_mvar,
+        capability_boundary=capability_boundary_from_args(args),
     )
 
     print(f"Intervals: {len(result.intervals)}")
     print(f"Response duration: {result.response_duration_minutes:.3f} minutes")
+    print(f"Reactive power obligation: {result.reactive_power_mvar:.3f} MVAr")
     print(f"Initial SOC: {result.initial_soc:.4f}")
     print(f"Ending SOC: {result.ending_soc:.4f}")
     print(f"Baseline AC energy: {result.baseline_ac_energy_mwh:.3f} MWh")
@@ -246,6 +277,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         "Reserve energy-limited intervals: "
         f"upward={result.upward_energy_limited_interval_count}, "
         f"downward={result.downward_energy_limited_interval_count}"
+    )
+    print(
+        "Reserve capability-limited intervals: "
+        f"upward={result.upward_capability_limited_interval_count}, "
+        f"downward={result.downward_capability_limited_interval_count}"
     )
     print(f"Auxiliary energy: {result.auxiliary_energy_mwh:.3f} MWh")
     print(f"Self-discharge energy: {result.self_discharge_energy_mwh:.3f} MWh")

--- a/tests/test_reserve_headroom.py
+++ b/tests/test_reserve_headroom.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import contextlib
 import io
 import unittest
+from pathlib import Path
 
 from models.energy_limits import StorageEnergyState
+from models.pq_capability import load_directional_capability_csv
 from models.reserve_headroom import calculate_reserve_headroom, main
 
 
@@ -63,6 +65,7 @@ class ReserveHeadroomTests(unittest.TestCase):
                 energy_capacity_mwh=200.0,
                 initial_soc=0.50,
             ),
+            capability_boundary=100.0,
         )
 
         self.assertEqual(result.upward_limit_active_mw, 20.0)
@@ -71,6 +74,57 @@ class ReserveHeadroomTests(unittest.TestCase):
         self.assertEqual(result.downward_reserve_mw, 10.0)
         self.assertFalse(result.upward_energy_limited)
         self.assertFalse(result.downward_energy_limited)
+        self.assertFalse(result.upward_capability_limited)
+        self.assertFalse(result.downward_capability_limited)
+
+    def test_circular_capability_preserves_reactive_power_and_limits_reserve(self):
+        result = calculate_reserve_headroom(
+            baseline_active_mw=10.0,
+            duration_minutes=30.0,
+            maximum_discharge_mw=100.0,
+            maximum_charge_mw=100.0,
+            state=StorageEnergyState(
+                energy_capacity_mwh=1000.0,
+                initial_soc=0.50,
+                charge_efficiency=1.0,
+                discharge_efficiency=1.0,
+            ),
+            reactive_power_mvar=80.0,
+            capability_boundary=100.0,
+        )
+
+        self.assertEqual(result.reactive_power_mvar, 80.0)
+        self.assertAlmostEqual(result.upward_limit_active_mw, 60.0)
+        self.assertAlmostEqual(result.downward_limit_active_mw, -60.0)
+        self.assertAlmostEqual(result.upward_reserve_mw, 50.0)
+        self.assertAlmostEqual(result.downward_reserve_mw, 70.0)
+        self.assertTrue(result.upward_capability_limited)
+        self.assertTrue(result.downward_capability_limited)
+        self.assertFalse(result.upward_energy_limited)
+        self.assertFalse(result.downward_energy_limited)
+
+    def test_directional_envelope_uses_each_active_power_quadrant(self):
+        repository = Path(__file__).resolve().parents[1]
+        envelope = load_directional_capability_csv(
+            repository / "models/data/illustrative_directional_capability.csv"
+        )
+
+        result = calculate_reserve_headroom(
+            baseline_active_mw=0.0,
+            duration_minutes=15.0,
+            maximum_discharge_mw=100.0,
+            maximum_charge_mw=100.0,
+            state=StorageEnergyState(1000.0, 0.50),
+            reactive_power_mvar=-70.0,
+            capability_boundary=envelope,
+        )
+
+        self.assertAlmostEqual(result.upward_limit_active_mw, 55.0)
+        self.assertAlmostEqual(result.downward_limit_active_mw, -40.0)
+        self.assertAlmostEqual(result.upward_reserve_mw, 55.0)
+        self.assertAlmostEqual(result.downward_reserve_mw, 40.0)
+        self.assertTrue(result.upward_capability_limited)
+        self.assertTrue(result.downward_capability_limited)
 
     def test_rejects_invalid_limits_and_unsustainable_baseline(self):
         state = StorageEnergyState(
@@ -85,6 +139,35 @@ class ReserveHeadroomTests(unittest.TestCase):
             calculate_reserve_headroom(2.0, 10.0, 1.0, 1.0, state)
         with self.assertRaisesRegex(ValueError, "cannot be sustained"):
             calculate_reserve_headroom(2.0, 60.0, 2.0, 2.0, state)
+        with self.assertRaisesRegex(ValueError, "capability_boundary is required"):
+            calculate_reserve_headroom(
+                0.0,
+                10.0,
+                10.0,
+                10.0,
+                state,
+                reactive_power_mvar=1.0,
+            )
+        with self.assertRaisesRegex(ValueError, "reactive_power_mvar exceeds"):
+            calculate_reserve_headroom(
+                0.0,
+                10.0,
+                100.0,
+                100.0,
+                state,
+                reactive_power_mvar=101.0,
+                capability_boundary=100.0,
+            )
+        with self.assertRaisesRegex(ValueError, "outside the capability boundary"):
+            calculate_reserve_headroom(
+                70.0,
+                10.0,
+                100.0,
+                100.0,
+                StorageEnergyState(1000.0, 0.50),
+                reactive_power_mvar=80.0,
+                capability_boundary=100.0,
+            )
 
     def test_operating_sweep_preserves_nonnegative_reserves(self):
         for initial_soc in (0.15, 0.30, 0.50, 0.70, 0.85):
@@ -135,6 +218,38 @@ class ReserveHeadroomTests(unittest.TestCase):
         self.assertIn("Downward reserve: 70.000 MW", output)
         self.assertIn("Upward energy limited: true", output)
         self.assertIn("Downward energy limited: true", output)
+
+    def test_cli_reports_capability_limited_reserve(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--baseline-active-mw",
+                    "10",
+                    "--duration-minutes",
+                    "30",
+                    "--maximum-discharge-mw",
+                    "100",
+                    "--maximum-charge-mw",
+                    "100",
+                    "--energy-capacity-mwh",
+                    "1000",
+                    "--initial-soc",
+                    "0.5",
+                    "--reactive-mvar",
+                    "80",
+                    "--limit-mva",
+                    "100",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Reactive power obligation: 80.000 MVAr", output)
+        self.assertIn("Upward reserve: 50.000 MW", output)
+        self.assertIn("Downward reserve: 70.000 MW", output)
+        self.assertIn("Upward capability limited: true", output)
+        self.assertIn("Downward capability limited: true", output)
 
 
 if __name__ == "__main__":

--- a/tests/test_reserve_sequence.py
+++ b/tests/test_reserve_sequence.py
@@ -117,6 +117,36 @@ class ReserveSequenceTests(unittest.TestCase):
             result.intervals[0].baseline_dispatch.ending_soc,
         )
 
+    def test_fixed_reactive_obligation_limits_each_sequence_interval(self):
+        result = audit_reserve_sequence(
+            [10.0, 10.0],
+            [15.0, 15.0],
+            30.0,
+            100.0,
+            100.0,
+            StorageEnergyState(
+                1000.0,
+                0.50,
+                charge_efficiency=1.0,
+                discharge_efficiency=1.0,
+            ),
+            reactive_power_mvar=80.0,
+            capability_boundary=100.0,
+        )
+
+        self.assertEqual(
+            [interval.reserve.upward_reserve_mw for interval in result.intervals],
+            [50.0, 50.0],
+        )
+        self.assertEqual(
+            [interval.reserve.downward_reserve_mw for interval in result.intervals],
+            [70.0, 70.0],
+        )
+        self.assertEqual(result.upward_capability_limited_interval_count, 2)
+        self.assertEqual(result.downward_capability_limited_interval_count, 2)
+        self.assertEqual(result.upward_energy_limited_interval_count, 0)
+        self.assertEqual(result.downward_energy_limited_interval_count, 0)
+
     def test_unsustainable_schedule_interval_is_rejected(self):
         with self.assertRaisesRegex(ValueError, "interval 1 cannot be sustained"):
             audit_reserve_sequence(
@@ -179,6 +209,39 @@ class ReserveSequenceTests(unittest.TestCase):
         self.assertIn("Minimum downward reserve: 40.000 MW (interval 1)", output)
         self.assertIn("upward=1, downward=3", output)
         self.assertIn("Interval 3: baseline=20.000 MW", output)
+
+    def test_cli_reports_sequence_capability_limit_counts(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--baseline-active-mw-profile",
+                    "10,10",
+                    "--interval-duration-minutes-profile",
+                    "15,15",
+                    "--response-duration-minutes",
+                    "30",
+                    "--maximum-discharge-mw",
+                    "100",
+                    "--maximum-charge-mw",
+                    "100",
+                    "--energy-capacity-mwh",
+                    "1000",
+                    "--initial-soc",
+                    "0.5",
+                    "--reactive-mvar",
+                    "80",
+                    "--limit-mva",
+                    "100",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Reactive power obligation: 80.000 MVAr", output)
+        self.assertIn("Minimum upward reserve: 50.000 MW", output)
+        self.assertIn("Minimum downward reserve: 70.000 MW", output)
+        self.assertIn("capability-limited intervals: upward=2, downward=2", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- preserve a fixed reactive obligation through circular, sampled, or directional P-Q boundaries
- apply capability limits before SOC limits and report each curtailment stage independently
- carry the same capability contract through multi-interval reserve audits

## Verification
- `python -m unittest discover -s tests -q` (148 tests)
- every executable reference command in `markdown-maintenance.yml`
- circular 100 MVA / 80 MVAr analytic limit: +/-60 MW
- directional -70 MVAr sample limits: +55/-40 MW
- `python -m compileall -q models tests`
- `git diff --check`
