### PR TITLE
Support reactive profiles in reserve audits

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -625,12 +625,29 @@ The baseline schedule is a firm input: an interval is rejected if its baseline
 cannot be delivered for the full schedule duration. Reserve limits are assessed
 from interval-start SOC and represent replacement setpoints held for the stated
 response duration; they do not simulate activation energy in addition to the
-baseline trajectory. Ramping, time-varying reactive dispatch, temperature
-derating, recovery requirements, and overlapping reserve activations remain
-separate constraints. The same `--reactive-mvar` and mutually exclusive P-Q
-boundary arguments carry a fixed reactive obligation through every interval;
-the summary reports how many upward and downward intervals are capability
-limited independently of their energy-limit counts.
+baseline trajectory. Ramping, temperature derating, recovery requirements, and
+overlapping reserve activations remain separate constraints. Use
+`--reactive-mvar` to carry one fixed obligation through every interval, or
+`--reactive-mvar-profile` with one comma-separated MVAr value per baseline
+interval when the voltage-support obligation changes during the schedule. A
+nonzero reactive obligation requires one of the mutually exclusive P-Q boundary
+arguments. The interval evidence prints the applied reactive value and the
+summary reports how many upward and downward intervals are capability-limited
+independently of their energy-limit counts.
+
+For example, assess a schedule that begins without reactive support and then
+must hold 80 MVAr:
+
+```powershell
+python models/reserve_sequence.py `
+  --baseline-active-mw-profile 10,10 `
+  --interval-duration-minutes-profile 15,15 `
+  --reactive-mvar-profile 0,80 `
+  --response-duration-minutes 30 `
+  --maximum-discharge-mw 100 --maximum-charge-mw 100 `
+  --energy-capacity-mwh 1000 --initial-soc 0.5 `
+  --limit-mva 100
+```
 
 ## Multi-Service Grid-Support Sequence
 

--- a/models/reserve_sequence.py
+++ b/models/reserve_sequence.py
@@ -48,7 +48,7 @@ class ReserveSequenceAudit:
 
     intervals: tuple[ReserveSequenceInterval, ...]
     response_duration_minutes: float
-    reactive_power_mvar: float
+    reactive_power_mvar_profile: tuple[float, ...]
     initial_soc: float
     ending_soc: float
     total_schedule_duration_minutes: float
@@ -76,6 +76,7 @@ def audit_reserve_sequence(
     state: StorageEnergyState,
     *,
     reactive_power_mvar: float = 0.0,
+    reactive_power_mvar_profile: Sequence[float] | None = None,
     capability_boundary: CapabilityBoundary | None = None,
 ) -> ReserveSequenceAudit:
     """Assess sustained reserve before each baseline interval and carry SOC."""
@@ -88,12 +89,26 @@ def audit_reserve_sequence(
         raise ValueError(
             "baseline_active_mw and interval_duration_minutes must have equal lengths"
         )
+    if reactive_power_mvar_profile is None:
+        reactive_profile = (reactive_power_mvar,) * len(baselines)
+    else:
+        reactive_profile = tuple(reactive_power_mvar_profile)
+        if reactive_power_mvar != 0.0:
+            raise ValueError(
+                "reactive_power_mvar must be zero when reactive_power_mvar_profile is set"
+            )
+        if len(reactive_profile) != len(baselines):
+            raise ValueError(
+                "reactive_power_mvar_profile and baseline_active_mw must have equal lengths"
+            )
+    if any(not math.isfinite(value) for value in reactive_profile):
+        raise ValueError("reactive_power_mvar_profile values must be finite")
 
     state.validate()
     interval_results: list[ReserveSequenceInterval] = []
     current_state = state
-    for index, (baseline_mw, interval_minutes) in enumerate(
-        zip(baselines, durations, strict=True),
+    for index, (baseline_mw, interval_minutes, reactive_mvar) in enumerate(
+        zip(baselines, durations, reactive_profile, strict=True),
         start=1,
     ):
         reserve = calculate_reserve_headroom(
@@ -102,7 +117,7 @@ def audit_reserve_sequence(
             maximum_discharge_mw=maximum_discharge_mw,
             maximum_charge_mw=maximum_charge_mw,
             state=current_state,
-            reactive_power_mvar=reactive_power_mvar,
+            reactive_power_mvar=reactive_mvar,
             capability_boundary=capability_boundary,
         )
         baseline_dispatch = limit_active_power_by_energy(
@@ -148,7 +163,7 @@ def audit_reserve_sequence(
     return ReserveSequenceAudit(
         intervals=intervals,
         response_duration_minutes=response_duration_minutes,
-        reactive_power_mvar=reactive_power_mvar,
+        reactive_power_mvar_profile=reactive_profile,
         initial_soc=state.initial_soc,
         ending_soc=ending_soc,
         total_schedule_duration_minutes=math.fsum(durations),
@@ -220,6 +235,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         type=_parse_number_series,
         required=True,
     )
+    parser.add_argument("--reactive-mvar-profile", type=_parse_number_series)
     parser.add_argument("--response-duration-minutes", type=float, required=True)
     parser.add_argument("--maximum-discharge-mw", type=float, required=True)
     parser.add_argument("--maximum-charge-mw", type=float, required=True)
@@ -254,12 +270,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             self_discharge_rate_per_hour=args.self_discharge_rate_per_hour,
         ),
         reactive_power_mvar=args.reactive_mvar,
+        reactive_power_mvar_profile=args.reactive_mvar_profile,
         capability_boundary=capability_boundary_from_args(args),
     )
 
     print(f"Intervals: {len(result.intervals)}")
     print(f"Response duration: {result.response_duration_minutes:.3f} minutes")
-    print(f"Reactive power obligation: {result.reactive_power_mvar:.3f} MVAr")
+    print(
+        "Reactive power profile: "
+        + ", ".join(f"{value:.3f}" for value in result.reactive_power_mvar_profile)
+        + " MVAr"
+    )
     print(f"Initial SOC: {result.initial_soc:.4f}")
     print(f"Ending SOC: {result.ending_soc:.4f}")
     print(f"Baseline AC energy: {result.baseline_ac_energy_mwh:.3f} MWh")
@@ -290,6 +311,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(
             f"Interval {interval.index}: "
             f"baseline={interval.reserve.baseline_active_mw:.3f} MW, "
+            f"reactive={interval.reserve.reactive_power_mvar:.3f} MVAr, "
             f"initial_soc={interval.baseline_dispatch.initial_soc:.4f}, "
             f"ending_soc={interval.baseline_dispatch.ending_soc:.4f}, "
             f"upward={interval.reserve.upward_reserve_mw:.3f} MW, "

--- a/tests/test_reserve_sequence.py
+++ b/tests/test_reserve_sequence.py
@@ -147,6 +147,39 @@ class ReserveSequenceTests(unittest.TestCase):
         self.assertEqual(result.upward_energy_limited_interval_count, 0)
         self.assertEqual(result.downward_energy_limited_interval_count, 0)
 
+    def test_reactive_profile_applies_the_correct_limit_each_interval(self):
+        result = audit_reserve_sequence(
+            [10.0, 10.0],
+            [15.0, 15.0],
+            30.0,
+            100.0,
+            100.0,
+            StorageEnergyState(1000.0, 0.50),
+            reactive_power_mvar_profile=[0.0, 80.0],
+            capability_boundary=100.0,
+        )
+
+        self.assertEqual(result.reactive_power_mvar_profile, (0.0, 80.0))
+        self.assertEqual(
+            [interval.reserve.upward_reserve_mw for interval in result.intervals],
+            [90.0, 50.0],
+        )
+        self.assertEqual(result.minimum_upward_reserve_interval, 2)
+
+    def test_reactive_profile_validates_length_and_scalar_conflict(self):
+        state = StorageEnergyState(100.0, 0.50)
+        with self.assertRaisesRegex(ValueError, "equal lengths"):
+            audit_reserve_sequence(
+                [0.0], [15.0], 15.0, 10.0, 10.0, state,
+                reactive_power_mvar_profile=[0.0, 1.0],
+            )
+        with self.assertRaisesRegex(ValueError, "must be zero"):
+            audit_reserve_sequence(
+                [0.0], [15.0], 15.0, 10.0, 10.0, state,
+                reactive_power_mvar=1.0,
+                reactive_power_mvar_profile=[0.0],
+            )
+
     def test_unsustainable_schedule_interval_is_rejected(self):
         with self.assertRaisesRegex(ValueError, "interval 1 cannot be sustained"):
             audit_reserve_sequence(
@@ -238,10 +271,32 @@ class ReserveSequenceTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         output = standard_output.getvalue()
-        self.assertIn("Reactive power obligation: 80.000 MVAr", output)
+        self.assertIn("Reactive power profile: 80.000, 80.000 MVAr", output)
         self.assertIn("Minimum upward reserve: 50.000 MW", output)
         self.assertIn("Minimum downward reserve: 70.000 MW", output)
         self.assertIn("capability-limited intervals: upward=2, downward=2", output)
+
+    def test_cli_reports_interval_reactive_profile(self):
+        standard_output = io.StringIO()
+        with contextlib.redirect_stdout(standard_output):
+            exit_code = main(
+                [
+                    "--baseline-active-mw-profile", "10,10",
+                    "--interval-duration-minutes-profile", "15,15",
+                    "--reactive-mvar-profile", "0,80",
+                    "--response-duration-minutes", "30",
+                    "--maximum-discharge-mw", "100",
+                    "--maximum-charge-mw", "100",
+                    "--energy-capacity-mwh", "1000",
+                    "--initial-soc", "0.5",
+                    "--limit-mva", "100",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        output = standard_output.getvalue()
+        self.assertIn("Reactive power profile: 0.000, 80.000 MVAr", output)
+        self.assertIn("Interval 2: baseline=10.000 MW, reactive=80.000 MVAr", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- accept a per-interval reactive-power profile in reserve-sequence audits
- evaluate each interval against its own P-Q obligation
- expose applied reactive power in interval evidence and document the workflow

## Validation
- python -m unittest discover -s tests -q (151 tests)
- interval-varying reactive-profile CLI smoke test