### PR TITLE
docs: add scope, citation, and license guidance

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,16 @@
+cff-version: 1.2.0
+message: "If you use this playbook or its reference models in research or teaching, please cite this repository."
+type: software
+title: "Smart Grid Storage Playbook"
+authors:
+  - family-names: Khan
+    given-names: Mohammad Rezwan
+    orcid: "https://orcid.org/0000-0002-1532-0598"
+repository-code: "https://github.com/mohammadrezwankhan/smart-grid-storage-playbook"
+url: "https://github.com/mohammadrezwankhan/smart-grid-storage-playbook"
+license: MIT
+keywords:
+  - smart grids
+  - grid-forming
+  - battery energy storage
+  - power systems

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 Explainable smart-grid and grid-forming BESS concepts for engineers, students,
 and project teams.
 
+## Documentation Map
+
+- [What this covers](#what-this-covers) sets the intended audience and domain.
+- [Starter pages](#starter-pages) is the concept and checklist reading path.
+- [Executable reference](#run-the-executable-reference) runs the dependency-free models.
+- [Model assumptions and limitations](models/README.md) defines the interpretation boundary.
+- [Contribution entry points](#contribution-entry-points) and [citation metadata](CITATION.cff) support shared work.
+
 ## What This Covers
 
 - Grid-following vs grid-forming storage.
@@ -92,6 +100,7 @@ case-notes/
 glossary/
 README.md
 CONTRIBUTING.md
+CITATION.cff
 LICENSE
 ```
 
@@ -182,6 +191,15 @@ battery warranty. The multi-interval energy reference reports separate AC and
 stored-energy throughput, conversion loss, and throughput-equivalent full
 cycles without claiming a degradation model.
 
+## Scope and Limitations
+
+This playbook is educational and a reference implementation, not a grid-code
+compliance determination, protection-setting approval, plant-controller
+specification, or battery-warranty assessment. The executable models use
+explicit assumptions and illustrative inputs; replace them with project data,
+validated equipment limits, applicable standards, and independent engineering
+review before using the results in a design or operational decision.
+
 ## Contribution Entry Points
 
 - Add a storage dispatch concept page.
@@ -211,3 +229,13 @@ cycles without claiming a degradation model.
 - Add project-specific examples to the service stacking conflict log.
 - Add project-specific examples to the system operator query log.
 - Add project-specific examples to the playbook next research questions.
+
+## Citation
+
+If this playbook supports research, teaching, or a project review, cite the
+machine-readable [CITATION.cff](CITATION.cff) metadata and identify the model
+assumptions, input profiles, and source material used.
+
+## License
+
+Released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

- add a documentation map for the concept, checklist, executable-model, limitation, contribution, and citation paths
- state the boundary between reference models and grid-code, protection, controller, or warranty decisions
- add validated `CITATION.cff` metadata and an explicit MIT license link

## Validation

- `python -m unittest discover -s tests -v` — passed
- `cffconvert --validate` — valid
- internal Markdown paths checked
- `git diff --check`
- commit signature verified by GitHub repository rules
